### PR TITLE
Update pending add-on releases to 2.6

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,7 +10,7 @@
 			<attribute name="FROM_GRADLE_MODEL" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ dependencies {
              'org.zaproxy:zap:2.5.0')
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 task generateReleaseNotes(type: JavaExec, dependsOn: 'classes') {
     group 'ZAP'


### PR DESCRIPTION
Change PendingAddOnReleases to use the ZapVersions file of 2.6 release,
also, include the period since the last release for each add-on.
Bump Java version to 8, easier to handle date calculations.