### PR TITLE
Update ZAP jar to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildDir = 'buildGradle'
 
 dependencies {
     compile ('net.sf.json-lib:json-lib:2.4:jdk15',
-             'org.zaproxy:zap:2.5.0')
+             'org.zaproxy:zap:2.6.0')
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Update ZAP jar to latest version (2.6.0), used by the "admin" tasks.