### PR TITLE
Update pending add-on releases to 2.7

### DIFF
--- a/src/main/java/org/zaproxy/admin/PendingAddOnReleases.java
+++ b/src/main/java/org/zaproxy/admin/PendingAddOnReleases.java
@@ -50,7 +50,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class PendingAddOnReleases {
 
-    private static final String ZAP_VERSIONS_FILE_NAME = "ZapVersions-2.6.xml";
+    private static final String ZAP_VERSIONS_FILE_NAME = "ZapVersions-2.7.xml";
     private static final String ZAP_ADD_ON_FILE_NAME = "ZapAddOn.xml";
 
     static {


### PR DESCRIPTION
Change PendingAddOnReleases to use the ZapVersions file of 2.7 release.