### PR TITLE
Release new versions of release/alpha add-ons

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -37,15 +37,16 @@
         <name>Active scanner rules</name>
         <description>The release quality Active Scanner rules</description>
         <author>ZAP Dev Team</author>
-        <version>30</version>
-        <file>ascanrules-release-30.zap</file>
+        <version>31</version>
+        <file>ascanrules-release-31.zap</file>
         <status>release</status>
-        <changes>Issue 1366: Allow SSI detection patterns to include new lines, and pre-check the original response for detection patterns to reduce false positives.&lt;br/&gt;
-    Issue 4168 and 4230: Pre-check the original response for detection patterns.&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-30.zap</url>
-        <hash>SHA1:728b9c76ac4a135db90181d701b0e7fd0f25a304</hash>
-        <date>2018-02-06</date>
-        <size>630842</size>
+        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
+    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
+    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
+        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
+        <date>2018-03-05</date>
+        <size>635944</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_ascanrules>
     
@@ -1070,19 +1071,17 @@
         <name>Content Security Policy Scanner</name>
         <description>Content Security Policy (CSP) Scanner</description>
         <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>cspscanner-alpha-4.zap</file>
+        <version>5</version>
+        <file>cspscanner-alpha-5.zap</file>
         <status>alpha</status>
-        <changes>Fixed missing error and warning messages.&lt;br&gt;
-		Added evidence.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/cspscanner-alpha-4.zap</url>
-        <hash>SHA1:643873300ce8bc7404054c8a8a8dec4f0c339cc2</hash>
-        <date>2017-11-28</date>
-        <size>160138</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
+        <changes>Minor code changes to address deprecations.&lt;br&gt;
+        Upgrade to Salvation library to 2.4.0.&lt;br&gt;
+        Added support for checking if prefetch-src allows wildcard sources.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/cspscanner-alpha-5.zap</url>
+        <hash>SHA1:5e0dc4766f8317a256610c81c28f90a3ed83ea7b</hash>
+        <date>2018-03-05</date>
+        <size>169214</size>
+        <not-before-version>2.7.0</not-before-version>
     </addon_cspscanner>
 
     <addon>customreport</addon>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -37,15 +37,16 @@
         <name>Active scanner rules</name>
         <description>The release quality Active Scanner rules</description>
         <author>ZAP Dev Team</author>
-        <version>30</version>
-        <file>ascanrules-release-30.zap</file>
+        <version>31</version>
+        <file>ascanrules-release-31.zap</file>
         <status>release</status>
-        <changes>Issue 1366: Allow SSI detection patterns to include new lines, and pre-check the original response for detection patterns to reduce false positives.&lt;br/&gt;
-    Issue 4168 and 4230: Pre-check the original response for detection patterns.&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-30.zap</url>
-        <hash>SHA1:728b9c76ac4a135db90181d701b0e7fd0f25a304</hash>
-        <date>2018-02-06</date>
-        <size>630842</size>
+        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
+    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
+    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
+        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
+        <date>2018-03-05</date>
+        <size>635944</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_ascanrules>
     
@@ -1070,19 +1071,17 @@
         <name>Content Security Policy Scanner</name>
         <description>Content Security Policy (CSP) Scanner</description>
         <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>cspscanner-alpha-4.zap</file>
+        <version>5</version>
+        <file>cspscanner-alpha-5.zap</file>
         <status>alpha</status>
-        <changes>Fixed missing error and warning messages.&lt;br&gt;
-		Added evidence.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/cspscanner-alpha-4.zap</url>
-        <hash>SHA1:643873300ce8bc7404054c8a8a8dec4f0c339cc2</hash>
-        <date>2017-11-28</date>
-        <size>160138</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
+        <changes>Minor code changes to address deprecations.&lt;br&gt;
+        Upgrade to Salvation library to 2.4.0.&lt;br&gt;
+        Added support for checking if prefetch-src allows wildcard sources.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/cspscanner-alpha-5.zap</url>
+        <hash>SHA1:5e0dc4766f8317a256610c81c28f90a3ed83ea7b</hash>
+        <date>2018-03-05</date>
+        <size>169214</size>
+        <not-before-version>2.7.0</not-before-version>
     </addon_cspscanner>
 
     <addon>customreport</addon>


### PR DESCRIPTION
Release:
 - Active scanner rules version 31.

Alpha:
 - Content Security Policy Scanner version 5.