### PR TITLE
Tidy up license headers

### DIFF
--- a/docs/headers/README.MD
+++ b/docs/headers/README.MD
@@ -1,1 +1,3 @@
 # Standard license headers to be used in zaproxy repos.
+
+Replace `$YEAR` with the current year.

--- a/docs/headers/license.java
+++ b/docs/headers/license.java
@@ -1,19 +1,19 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
- * Copyright 2018 The ZAP Development Team
- *  
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ *
+ * Copyright $YEAR The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */

--- a/docs/headers/license.script
+++ b/docs/headers/license.script
@@ -1,17 +1,18 @@
+#
 # Zed Attack Proxy (ZAP) and its related class files.
-# 
+#
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
-# 
-# Copyright 2018 The ZAP Development Team
-#  
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
-# You may obtain a copy of the License at 
-# 
-#   http://www.apache.org/licenses/LICENSE-2.0 
-#   
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
-# limitations under the License. 
+#
+# Copyright $YEAR The ZAP Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Remove white spaces at the end of the lines and in empty lines and
remove last empty line (not part of the header).
Replace the year with a token, so that it does not require update the
headers each year (it's up to the tool or user to replace it with the
current one). Update README to mention that.