### PR TITLE
Validate ZapVersions.xml files

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,6 +10,11 @@
 			<attribute name="FROM_GRADLE_MODEL" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="src/test/java">
+		<attributes>
+			<attribute name="FROM_GRADLE_MODEL" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin"/>

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,25 @@ buildDir = 'buildGradle'
 dependencies {
     compile ('net.sf.json-lib:json-lib:2.4:jdk15',
              'org.zaproxy:zap:2.6.0')
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+sourceSets {
+    test {
+        resources {
+            srcDir 'src/test/resources'
+        }
+        resources {
+            srcDir "$rootDir"
+            include 'ZapVersions*.xml'
+        }
+    }
+}
 
 spotless {
     java {

--- a/src/test/java/org/zaproxy/admin/ValidateZapVersionsXmlTest.java
+++ b/src/test/java/org/zaproxy/admin/ValidateZapVersionsXmlTest.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.admin;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.zaproxy.zap.control.AddOnCollection;
+import org.zaproxy.zap.control.AddOnCollection.Platform;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Validates that ZAP is able to load the {@code ZapVersions.xml} files. */
+public class ValidateZapVersionsXmlTest {
+
+    private static final File ZAP_VERSIONS_CURR = resource("/ZapVersions-2.7.xml");
+    private static final File ZAP_VERSIONS_DEV = resource("/ZapVersions-dev.xml");
+    private static final File ZAP_VERSIONS = resource("/ZapVersions.xml");
+
+    private static final List<Platform> PLATFORMS =
+            Arrays.asList(Platform.linux, Platform.windows, Platform.mac, Platform.daily);
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test
+    public void shouldLoadCurrentVersion() throws Exception {
+        // Given
+        for (Platform platform : PLATFORMS) {
+            // When
+            AddOnCollection aoc =
+                    new AddOnCollection(new ZapXmlConfiguration(ZAP_VERSIONS_CURR), platform);
+            // Then
+            assertReleaseAndAddOnsPresent(aoc, platform);
+        }
+    }
+
+    private static void assertReleaseAndAddOnsPresent(AddOnCollection aoc, Platform platform) {
+        assertThat("Release not found for: " + platform, aoc.getZapRelease(), is(notNullValue()));
+        assertThat("No add-ons for: " + platform, aoc.getAddOns(), is(not(empty())));
+    }
+
+    @Test
+    public void shouldLoadDevVersion() throws Exception {
+        // Given
+        for (Platform platform : PLATFORMS) {
+            // When
+            AddOnCollection aoc =
+                    new AddOnCollection(new ZapXmlConfiguration(ZAP_VERSIONS_DEV), platform);
+            // Then
+            assertReleaseAndAddOnsPresent(aoc, platform);
+        }
+    }
+
+    @Test
+    public void shouldLoadNonAddOnsVariant() throws Exception {
+        // Given
+        for (Platform platform : PLATFORMS) {
+            // When
+            AddOnCollection aoc =
+                    new AddOnCollection(new ZapXmlConfiguration(ZAP_VERSIONS), platform);
+            // Then
+            assertThat(aoc.getZapRelease(), is(notNullValue()));
+        }
+    }
+
+    private static File resource(String path) {
+        return new File(ValidateZapVersionsXmlTest.class.getResource(path).getPath());
+    }
+}


### PR DESCRIPTION
Add test to assert that ZAP is able to parse/load the ZapVersions.xml
files (current version, dev, and without add-ons).