### PR TITLE
attacksurfacedetector: release version 1.1.1

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -49,6 +49,22 @@
         <size>635944</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_ascanrules>
+
+    <addon>attacksurfacedetector</addon>
+    <addon_attacksurfacedetector>
+        <name>Attack Surface Detector</name>
+        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
+        <author>Secure Decisions (Matthew DeLetto)</author>
+        <version>1.1.1</version>
+        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
+        <status>alpha</status>
+        <changes>First Version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
+        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
+        <date>2018-06-28</date>
+        <size>14387774</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_attacksurfacedetector>
     
     <addon>coreLang</addon>
     <addon_coreLang>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -49,6 +49,22 @@
         <size>635944</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_ascanrules>
+
+    <addon>attacksurfacedetector</addon>
+    <addon_attacksurfacedetector>
+        <name>Attack Surface Detector</name>
+        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
+        <author>Secure Decisions (Matthew DeLetto)</author>
+        <version>1.1.1</version>
+        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
+        <status>alpha</status>
+        <changes>First Version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
+        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
+        <date>2018-06-28</date>
+        <size>14387774</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_attacksurfacedetector>
     
     <addon>coreLang</addon>
     <addon_coreLang>


### PR DESCRIPTION
Release version 1.1.1 of Attack Surface Detector add-on.

For zaproxy/zaproxy#4670.