### PR TITLE
Normalise ZapVersions.xml files

### DIFF
--- a/ZapVersions-2.4.xml
+++ b/ZapVersions-2.4.xml
@@ -1,37 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
-	
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
+    <addon>accessControl</addon>
+    <addon_accessControl>
+        <name>Access Control Testing</name>
+        <description>Adds a set of tools for testing access control in web applications.</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>accessControl-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>Initial version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/accessControl-alpha-1.zap</url>
+        <hash>SHA1:92a1bca6711f223e1eaff7e577307d835bcaf9f7</hash>
+        <date>2015-04-13</date>
+        <size>444307</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_accessControl>
+    <addon>alertFilters</addon>
+    <addon_alertFilters>
+        <name>Context Alert Filters</name>
+        <description>Allows you to automate the changing of alert risk levels.</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>alertFilters-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Updated to use alertIds from 2.4.3+&lt;br&gt;
+	Misc minor bug fixes&lt;br&gt;
+	HTML report reports the filtered false positives as true results (Issue 2311)&lt;br&gt;
+	Promoted to beta and added icon&lt;br&gt;
+	Various minor UI improvements&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/alertFilters-beta-2.zap</url>
+        <hash>SHA1:bc97e3b0a8b4955662377c6a652193acd8833bfa</hash>
+        <date>2016-03-22</date>
+        <size>263798</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_alertFilters>
+    <addon>alertReport</addon>
+    <addon_alertReport>
+        <name>Report alert generator</name>
+        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
+        <author>Talsoft SRL</author>
+        <version>14</version>
+        <file>alertReport-beta-14.zap</file>
+        <status>beta</status>
+        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
+	Include Alert's evidence in report of ODT format.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/alertReport-beta-14.zap</url>
+        <hash>SHA1:70306adc9e2f1ab6c00efe9c46c22e4047ea10fa</hash>
+        <info>http://www.talsoft.com.ar</info>
+        <date>2015-07-27</date>
+        <size>9721300</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_alertReport>
+    <addon>amf</addon>
+    <addon_amf>
+        <name>AMF</name>
+        <description>Adds support for AMF messages</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>amf-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First release as an add-on, previously bundled with core.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/amf-alpha-1.zap</url>
+        <hash>SHA1:56e8f859ac538a9b7b1d6d8022cc406f8accbcb1</hash>
+        <date>2015-08-16</date>
+        <size>808303</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_amf>
     <addon>ascanrules</addon>
     <addon_ascanrules>
         <name>Active scanner rules</name>
@@ -50,7 +114,138 @@
         <size>551792</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_ascanrules>
-    
+    <addon>ascanrulesAlpha</addon>
+    <addon_ascanrulesAlpha>
+        <name>Active scanner rules (alpha)</name>
+        <description>The alpha quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>15</version>
+        <file>ascanrulesAlpha-alpha-15.zap</file>
+        <status>alpha</status>
+        <changes>Update add-on's info URL.&lt;br&gt;
+    Added Integer Overflow scanner.&lt;br&gt;
+    Added new scanner User Agent Fuzzer. The scanner checks for differences in response based on fuzzed User Agent.&lt;br&gt;
+    Slightly improve performance of "Source Code Disclosure - File Inclusion".&lt;br&gt;
+    Demoted LDAP rule due to performance issues</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/ascanrulesAlpha-alpha-15.zap</url>
+        <hash>SHA1:52f9b52561ba82e83ab6808e2a428135ecc7a8ef</hash>
+        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
+        <date>2015-12-04</date>
+        <size>1312312</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_ascanrulesAlpha>
+    <addon>ascanrulesBeta</addon>
+    <addon_ascanrulesBeta>
+        <name>Active scanner rules (beta)</name>
+        <description>The beta quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>19</version>
+        <file>ascanrulesBeta-beta-19.zap</file>
+        <status>beta</status>
+        <changes>Adding Integer Overflow Scanner.&lt;br&gt;
+	Issue 823: i18n (internationalise) beta active scan rules.&lt;br&gt;
+	Issue 1713: Source Code Disclosure SVN Throws False Positive - Fixed.&lt;br&gt;
+	Add CWE and WASC IDs to active scanners which may have been lacking those details.&lt;br&gt;
+	Create help for scanners which were missing entries.&lt;br&gt;
+	Issue 2180: Adjust logging, and implement plugin skip if runtime requirements not met.&lt;/br&gt;
+	Security fixes, to be detailed later.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/ascanrulesBeta-beta-19.zap</url>
+        <hash>SHA1:ae9902333c56f6e1ac1d4aeaa5967e92758c2852</hash>
+        <date>2016-02-05</date>
+        <size>2585546</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_ascanrulesBeta>
+    <addon>beanshell</addon>
+    <addon_beanshell>
+        <name>BeanShell Console</name>
+        <description>Provides a BeanShell Console</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>beanshell-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/beanshell-beta-5.zap</url>
+        <hash>SHA1:232de4af6f0d7671aafd14f40ec6f0aea6ec48a1</hash>
+        <date>2015-04-13</date>
+        <size>547816</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_beanshell>
+    <addon>browserView</addon>
+    <addon_browserView>
+        <name>Browser View</name>
+        <description>Adds an option to render HTML responses like a browser</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>browserView-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/browserView-alpha-4.zap</url>
+        <hash>SHA1:dc770d05e90b1ca0ea865c828be24532d393e21e</hash>
+        <date>2015-04-13</date>
+        <size>174828</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_browserView>
+    <addon>bruteforce</addon>
+    <addon_bruteforce>
+        <name>Forced Browse</name>
+        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>bruteforce-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Adding request count on Forced browser tab as specified on issue #1873</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/bruteforce-beta-5.zap</url>
+        <hash>SHA1:141140a0c2e4cbf196d45566d362e9823498172a</hash>
+        <date>2015-12-04</date>
+        <size>1000226</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_bruteforce>
+    <addon>callgraph</addon>
+    <addon_callgraph>
+        <name>Call Graph</name>
+        <description>Allows the user to view a call graph of the selected resources</description>
+        <author>Colm O'Flaherty</author>
+        <version>3</version>
+        <file>callgraph-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/callgraph-alpha-3.zap</url>
+        <hash>SHA1:7e5f464cab9f948f6f84d9c480e48b45b8f0dd84</hash>
+        <date>2015-04-13</date>
+        <size>1143369</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_callgraph>
+    <addon>codedx</addon>
+    <addon_codedx>
+        <name>Code Dx Extension</name>
+        <description>includes request and response data in xml reports</description>
+        <author>Code Dx, Inc.</author>
+        <version>2</version>
+        <file>codedx-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Rework HTML tags in reports</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/codedx-alpha-2.zap</url>
+        <hash>SHA1:f3236e638d96e14380e1f89c7c3ca2b6f9b7990e</hash>
+        <date>2015-12-04</date>
+        <size>22196</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_codedx>
+    <addon>communityScripts</addon>
+    <addon_communityScripts>
+        <name>Community Scripts</name>
+        <description>Useful ZAP scripts written by the ZAP community.</description>
+        <author>ZAP Community</author>
+        <version>2</version>
+        <file>communityScripts-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Fixed bug which prevents ZAP configs from being saved correctly&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/communityScripts-alpha-2.zap</url>
+        <hash>SHA1:74ac7f864454b32dd6a985d6b169c3f26c77ac88</hash>
+        <info>https://github.com/zaproxy/community-scripts</info>
+        <date>2016-02-17</date>
+        <size>129034</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_communityScripts>
     <addon>coreLang</addon>
     <addon_coreLang>
         <name>Core Language Files</name>
@@ -67,7 +262,36 @@
         <size>2582669</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_coreLang>
-    
+    <addon>customreport</addon>
+    <addon_customreport>
+        <name>CustomReport</name>
+        <description>New HTML report module allows users to customize report content.</description>
+        <author>Chienli Ma</author>
+        <version>1</version>
+        <file>customreport-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/customreport-alpha-1.zap</url>
+        <hash>SHA1:235bc5518455394c0d5081e314fbffeb8638156f</hash>
+        <date>2015-12-04</date>
+        <size>555935</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_customreport>
+    <addon>diff</addon>
+    <addon_diff>
+        <name>Diff</name>
+        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>diff-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Do not add line break tags to resultant diff (Issue 1571)&lt;br&gt;
+    Automatically close the diff dialogue when uninstalling.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/diff-beta-6.zap</url>
+        <hash>SHA1:f7b7b9c76ef35c4deaabf57cfe81b6b2c65cdf28</hash>
+        <date>2015-12-04</date>
+        <size>234656</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_diff>
     <addon>directorylistv1</addon>
     <addon_directorylistv1>
         <name>Directory List v1.0</name>
@@ -85,7 +309,6 @@
         <size>847601</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv1>
-    
     <addon>directorylistv2_3</addon>
     <addon_directorylistv2_3>
         <name>Directory List v2.3</name>
@@ -103,7 +326,6 @@
         <size>8608719</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3>
-    
     <addon>directorylistv2_3_lc</addon>
     <addon_directorylistv2_3_lc>
         <name>Directory List v2.3 LC</name>
@@ -120,7 +342,50 @@
         <size>7454751</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3_lc>
-    
+    <addon>domxss</addon>
+    <addon_domxss>
+        <name>DOM XSS Active scanner rule</name>
+        <description>DOM XSS Active scanner rule</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>domxss-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Change (duplicated) scanner ID, now it's 40026.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/domxss-alpha-2.zap</url>
+        <hash>SHA1:083b18d47649463cb894a4b7f78224ad7eee3499</hash>
+        <date>2015-12-04</date>
+        <size>191683</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>1.*</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_domxss>
+    <addon>fuzz</addon>
+    <addon_fuzz>
+        <name>AdvFuzzer</name>
+        <description>Advanced fuzzer for manual testing</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <semver>2.0.1</semver>
+        <file>fuzz-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Added Export button to export results as CSV file.&lt;br&gt;
+    Enable "Limit maximum errors" by default and increase the default number.&lt;br&gt;
+    Improve error handling when reading/writing files from/to fuzzers directory.&lt;br&gt;
+    Add SHA-512 Hash payload processor (Issue 2643).&lt;br&gt;
+    Allow to search the fuzzer file names when selecting them.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/fuzz-beta-6.zap</url>
+        <hash>SHA1:b49dea08655edaab20d0c72f706177b288cf3091</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
+        <date>2016-07-14</date>
+        <size>2193035</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_fuzz>
     <addon>fuzzdb</addon>
     <addon_fuzzdb>
         <name>Fuzzdb files</name>
@@ -137,7 +402,6 @@
         <size>7211698</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_fuzzdb>
-    
     <addon>gettingStarted</addon>
     <addon_gettingStarted>
         <name>Getting Started with ZAP Guide</name>
@@ -153,7 +417,6 @@
         <size>270135</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_gettingStarted>
-    
     <addon>help</addon>
     <addon_help>
         <name>Help - English</name>
@@ -170,7 +433,70 @@
         <size>711029</size>
         <not-before-version>2.4.3</not-before-version>
     </addon_help>
-
+    <addon>help_bs_BA</addon>
+    <addon_help_bs_BA>
+        <name>Help - Bosnian</name>
+        <description>Bosnian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>4</version>
+        <file>help_bs_BA-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.4.3</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_bs_BA-alpha-4.zap</url>
+        <hash>SHA1:35c5b1b5f1a5cada187be51b50fda04d9b84edfa</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2015-12-04</date>
+        <size>728733</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_help_bs_BA>
+    <addon>help_es_ES</addon>
+    <addon_help_es_ES>
+        <name>Help - Spanish</name>
+        <description>Spanish version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>4</version>
+        <file>help_es_ES-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.4.3</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_es_ES-alpha-4.zap</url>
+        <hash>SHA1:e47e9fb0ee21ae2612b4bc16f83b5c504f389442</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2015-12-04</date>
+        <size>731964</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_help_es_ES>
+    <addon>help_fr_FR</addon>
+    <addon_help_fr_FR>
+        <name>Help - French</name>
+        <description>French version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>4</version>
+        <file>help_fr_FR-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.4.3</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_fr_FR-alpha-4.zap</url>
+        <hash>SHA1:803e9ff2a6ef6342dcf8b9fe1f8ea5059c98ad90</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2015-12-04</date>
+        <size>728018</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_help_fr_FR>
+    <addon>help_ja_JP</addon>
+    <addon_help_ja_JP>
+        <name>Help - Japanese</name>
+        <description>Japanese version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>4</version>
+        <file>help_ja_JP-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.4.3</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_ja_JP-alpha-4.zap</url>
+        <hash>SHA1:5981c8e3924145ce2762d87aa2c80b3d036f4acf</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2015-12-04</date>
+        <size>755403</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_help_ja_JP>
     <addon>help_pt_BR</addon>
     <addon_help_pt_BR>
         <name>Help - Portuguese, Brazilian</name>
@@ -187,7 +513,113 @@
         <size>766697</size>
         <not-before-version>2.4.3</not-before-version>
     </addon_help_pt_BR>
-    
+    <addon>highlighter</addon>
+    <addon_highlighter>
+        <name>Highlighter</name>
+        <description>Allows you to highlight strings in the request and response tabs.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>highlighter-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/highlighter-alpha-6.zap</url>
+        <hash>SHA1:211f40cedfb7e72e948561bd2c02e7424ddf53de</hash>
+        <date>2015-04-13</date>
+        <size>9562</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_highlighter>
+    <addon>httpsInfo</addon>
+    <addon_httpsInfo>
+        <name>HttpsInfo</name>
+        <description>Adds Https status information</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>httpsInfo-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Issue 1978 Uncaught NPE - Fixed.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/httpsInfo-alpha-6.zap</url>
+        <hash>SHA1:08b55236c4a67d68e99db7ed37b291f65edd70c7</hash>
+        <date>2015-12-04</date>
+        <size>51818</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_httpsInfo>
+    <addon>importLogFiles</addon>
+    <addon_importLogFiles>
+        <name>Log File Importer</name>
+        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>importLogFiles-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Updated add-on's info URL.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/importLogFiles-alpha-3.zap</url>
+        <hash>SHA1:43308016f687eb673d783425e2bb5279920ca3ce</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
+        <date>2015-09-07</date>
+        <size>151944</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_importLogFiles>
+    <addon>importurls</addon>
+    <addon_importurls>
+        <name>Import files containing URLs</name>
+        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>importurls-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Promoted to beta, updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/importurls-beta-2.zap</url>
+        <hash>SHA1:59cb337708eb12372855391c2b600062167acced</hash>
+        <date>2015-04-13</date>
+        <size>200107</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_importurls>
+    <addon>invoke</addon>
+    <addon_invoke>
+        <name>Invoke Applications</name>
+        <description>Invoke external applications passing context related information such as URLs and parameters</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>invoke-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Allow to invoke the applications in all UI components that show HTTP messages.&lt;br&gt;
+    Allow to manually specify the application path and working directory (Issue 2708).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/invoke-beta-4.zap</url>
+        <hash>SHA1:76d2c426b4afbb23ddd8b514fe8b3f3fbd07d093</hash>
+        <date>2016-08-03</date>
+        <size>283768</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_invoke>
+    <addon>jruby</addon>
+    <addon_jruby>
+        <name>Ruby scripting</name>
+        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jruby-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/jruby-beta-4.zap</url>
+        <hash>SHA1:0759a375e16ef4b01c2bd46c997c3d1de116aa21</hash>
+        <date>2015-04-13</date>
+        <size>22208105</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jruby>
+    <addon>jython</addon>
+    <addon_jython>
+        <name>Python scripting</name>
+        <description>Allows Python to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jython-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/jython-beta-4.zap</url>
+        <hash>SHA1:e89573c9b5fa380a1c4f3fc812b1841105632978</hash>
+        <date>2015-04-13</date>
+        <size>14545042</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jython>
     <addon>onlineMenu</addon>
     <addon_onlineMenu>
         <name>Online menus</name>
@@ -205,7 +637,40 @@
         <size>199593</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_onlineMenu>
-    
+    <addon>plugnhack</addon>
+    <addon_plugnhack>
+        <name>Plug-n-Hack Configuration</name>
+        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>plugnhack-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Require API key before returning it (Issue 1714)&lt;br&gt;
+    Restrict use of CORS header in pnh (Issue 1716)&lt;br&gt;
+    Auto-scroll when new client events are available (Issue 1664)</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/plugnhack-beta-9.zap</url>
+        <hash>SHA1:9cccd811449afa171b31960d371fd93e9ebb1a89</hash>
+        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
+        <date>2015-08-23</date>
+        <size>507813</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_plugnhack>
+    <addon>portscan</addon>
+    <addon_portscan>
+        <name>Port Scanner</name>
+        <description>Allows to port scan a target server</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>portscan-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.&lt;br&gt;
+    Do not access view components when view is not initialised (Issue 1617).</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/portscan-beta-7.zap</url>
+        <hash>SHA1:71f8aaece1224fb3859cfe2c56630aacb1ef8f03</hash>
+        <date>2015-12-04</date>
+        <size>602634</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_portscan>
     <addon>pscanrules</addon>
     <addon_pscanrules>
         <name>Passive scanner rules</name>
@@ -225,7 +690,38 @@
         <size>441313</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_pscanrules>
-    
+    <addon>pscanrulesAlpha</addon>
+    <addon_pscanrulesAlpha>
+        <name>Passive scanner rules (alpha)</name>
+        <description>The alpha quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>pscanrulesAlpha-alpha-10.zap</file>
+        <status>alpha</status>
+        <changes>XPoweredByHeaderInfoLeakScanner modify evidence (Issue 2575)&lt;br&gt;
+		ContentSecurityPolicyMissingScanner to only check for older CSP headers at Low threshold&lt;br&gt;
+		CacheableScanner: Add other information in attack and remove evidence (Issue 2573)&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesAlpha-alpha-10.zap</url>
+        <hash>SHA1:1fc881177fd0e629c8c0b97480e96cdcd51cb052</hash>
+        <date>2016-06-22</date>
+        <size>1850422</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_pscanrulesAlpha>
+    <addon>pscanrulesBeta</addon>
+    <addon_pscanrulesBeta>
+        <name>Passive scanner rules (beta)</name>
+        <description>The beta quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>12</version>
+        <file>pscanrulesBeta-beta-12.zap</file>
+        <status>beta</status>
+        <changes>Change (duplicated) scanner ID of Weak Authentication Method, now it's 10105.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/pscanrulesBeta-beta-12.zap</url>
+        <hash>SHA1:083f33e5878237ef45a795f39c8d5d3590260d20</hash>
+        <date>2015-12-04</date>
+        <size>386237</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_pscanrulesBeta>
     <addon>quickstart</addon>
     <addon_quickstart>
         <name>Quick Start</name>
@@ -242,7 +738,6 @@
         <size>340761</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_quickstart>
-
     <addon>requester</addon>
     <addon_requester>
         <name>Requester</name>
@@ -257,7 +752,6 @@
         <size>40411</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_requester>
-    
     <addon>reveal</addon>
     <addon_reveal>
         <name>Reveal</name>
@@ -273,7 +767,38 @@
         <size>213139</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_reveal>
-    
+    <addon>revisit</addon>
+    <addon_revisit>
+        <name>Revisit</name>
+        <description>Revisit a site at any time in the past using the session history</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>revisit-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/revisit-alpha-1.zap</url>
+        <hash>SHA1:dd656f51d67659486634d14d743cdfabbdcc4b88</hash>
+        <date>2015-10-26</date>
+        <size>82810</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_revisit>
+    <addon>saml</addon>
+    <addon_saml>
+        <name>SAML Extension</name>
+        <description>Detect, Show, Edit, Fuzz SAML requests</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>saml-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Internationalise and show 'SAML Actions' menu.&lt;br&gt;
+	Security fixes, to be detailed later.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/saml-alpha-5.zap</url>
+        <hash>SHA1:9d1e9eb975ae2428b99f7e0a88f9cab1c07f0aaa</hash>
+        <info>https://github.com/zaproxy/zaproxy</info>
+        <date>2016-02-05</date>
+        <size>994451</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_saml>
     <addon>saverawmessage</addon>
     <addon_saverawmessage>
         <name>Save Raw Message</name>
@@ -289,7 +814,23 @@
         <size>24648</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_saverawmessage>
-    
+    <addon>scripts</addon>
+    <addon_scripts>
+        <name>Script Console</name>
+        <description>Supports all JSR 223 scripting languages</description>
+        <author>ZAP Dev Team</author>
+        <version>15</version>
+        <file>scripts-beta-15.zap</file>
+        <status>beta</status>
+        <changes>Issue 1653: Support context menu key for trees.&lt;br&gt;
+    Updated add-on's info URL.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/scripts-beta-15.zap</url>
+        <hash>SHA1:23d803f7521e268fd3e1eb4f28bc488ded124b32</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
+        <date>2015-08-23</date>
+        <size>505975</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_scripts>
     <addon>selenium</addon>
     <addon_selenium>
         <name>Selenium</name>
@@ -306,7 +847,55 @@
         <size>31702670</size>
         <not-before-version>2.4.3</not-before-version>
     </addon_selenium>
-    
+    <addon>sequence</addon>
+    <addon_sequence>
+        <name>Sequence</name>
+        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>sequence-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Updated to latest core changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sequence-alpha-2.zap</url>
+        <hash>SHA1:97ef0d02e5fbc26a82c50b32f93906049c57aafb</hash>
+        <date>2015-09-07</date>
+        <size>35673</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_sequence>
+    <addon>sniTerminator</addon>
+    <addon_sniTerminator>
+        <name>SNI Terminator</name>
+        <description>Transparent HTTP proxying</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>sniTerminator-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Update library to work with newer versions of ZAP.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sniTerminator-alpha-4.zap</url>
+        <hash>SHA1:c6e18d4e1fb7d9b1194584f897d6d87bc7226209</hash>
+        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
+        <date>2016-05-30</date>
+        <size>247164</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_sniTerminator>
+    <addon>soap</addon>
+    <addon_soap>
+        <name>SOAP Scanner</name>
+        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
+        <author>Alberto (albertov91)</author>
+        <version>2</version>
+        <file>soap-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Fixes a problem where operations under the same location were overwritten. Other minor fixes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/soap-alpha-2.zap</url>
+        <hash>SHA1:c6076ed993bece3ca0b67c4fe308944ecc61c0f4</hash>
+        <date>2015-09-07</date>
+        <size>7282070</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_soap>
     <addon>spiderAjax</addon>
     <addon_spiderAjax>
         <name>Ajax Spider</name>
@@ -331,290 +920,6 @@
             </addons>
         </dependencies>
     </addon_spiderAjax>
-    
-    <addon>websocket</addon>
-    <addon_websocket>
-        <name>WebSockets</name>
-        <description>Allows you to inspect WebSocket communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>websocket-release-10.zap</file>
-        <status>release</status>
-        <changes>Fix issue with length of handshake's url (Issue 2097).&lt;br&gt;
-    Restore fuzzing capabilities (Issue 1905).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/websocket-release-10.zap</url>
-        <hash>SHA1:e323ca749b9aa77040f3366a5924c2a6173e5be1</hash>
-        <date>2015-12-04</date>
-        <size>823387</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_websocket>
-
-    <addon>alertFilters</addon>
-    <addon_alertFilters>
-        <name>Context Alert Filters</name>
-        <description>Allows you to automate the changing of alert risk levels.</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>alertFilters-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Updated to use alertIds from 2.4.3+&lt;br&gt;
-	Misc minor bug fixes&lt;br&gt;
-	HTML report reports the filtered false positives as true results (Issue 2311)&lt;br&gt;
-	Promoted to beta and added icon&lt;br&gt;
-	Various minor UI improvements&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/alertFilters-beta-2.zap</url>
-        <hash>SHA1:bc97e3b0a8b4955662377c6a652193acd8833bfa</hash>
-        <date>2016-03-22</date>
-        <size>263798</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_alertFilters>
-
-    <addon>alertReport</addon>
-    <addon_alertReport>
-        <name>Report alert generator</name>
-        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
-        <author>Talsoft SRL</author>
-        <version>14</version>
-        <file>alertReport-beta-14.zap</file>
-        <status>beta</status>
-        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
-	Include Alert's evidence in report of ODT format.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/alertReport-beta-14.zap</url>
-        <hash>SHA1:70306adc9e2f1ab6c00efe9c46c22e4047ea10fa</hash>
-        <info>http://www.talsoft.com.ar</info>
-        <date>2015-07-27</date>
-        <size>9721300</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_alertReport>
-    
-    <addon>ascanrulesBeta</addon>
-    <addon_ascanrulesBeta>
-        <name>Active scanner rules (beta)</name>
-        <description>The beta quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>19</version>
-        <file>ascanrulesBeta-beta-19.zap</file>
-        <status>beta</status>
-        <changes>Adding Integer Overflow Scanner.&lt;br&gt;
-	Issue 823: i18n (internationalise) beta active scan rules.&lt;br&gt;
-	Issue 1713: Source Code Disclosure SVN Throws False Positive - Fixed.&lt;br&gt;
-	Add CWE and WASC IDs to active scanners which may have been lacking those details.&lt;br&gt;
-	Create help for scanners which were missing entries.&lt;br&gt;
-	Issue 2180: Adjust logging, and implement plugin skip if runtime requirements not met.&lt;/br&gt;
-	Security fixes, to be detailed later.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/ascanrulesBeta-beta-19.zap</url>
-        <hash>SHA1:ae9902333c56f6e1ac1d4aeaa5967e92758c2852</hash>
-        <date>2016-02-05</date>
-        <size>2585546</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_ascanrulesBeta>
-    
-    <addon>beanshell</addon>
-    <addon_beanshell>
-        <name>BeanShell Console</name>
-        <description>Provides a BeanShell Console</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>beanshell-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/beanshell-beta-5.zap</url>
-        <hash>SHA1:232de4af6f0d7671aafd14f40ec6f0aea6ec48a1</hash>
-        <date>2015-04-13</date>
-        <size>547816</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_beanshell>
-    
-    <addon>bruteforce</addon>
-    <addon_bruteforce>
-        <name>Forced Browse</name>
-        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>bruteforce-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Adding request count on Forced browser tab as specified on issue #1873</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/bruteforce-beta-5.zap</url>
-        <hash>SHA1:141140a0c2e4cbf196d45566d362e9823498172a</hash>
-        <date>2015-12-04</date>
-        <size>1000226</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_bruteforce>
-    
-    <addon>diff</addon>
-    <addon_diff>
-        <name>Diff</name>
-        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>diff-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Do not add line break tags to resultant diff (Issue 1571)&lt;br&gt;
-    Automatically close the diff dialogue when uninstalling.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/diff-beta-6.zap</url>
-        <hash>SHA1:f7b7b9c76ef35c4deaabf57cfe81b6b2c65cdf28</hash>
-        <date>2015-12-04</date>
-        <size>234656</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_diff>
-    
-    <addon>fuzz</addon>
-    <addon_fuzz>
-        <name>AdvFuzzer</name>
-        <description>Advanced fuzzer for manual testing</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <semver>2.0.1</semver>
-        <file>fuzz-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Added Export button to export results as CSV file.&lt;br&gt;
-    Enable "Limit maximum errors" by default and increase the default number.&lt;br&gt;
-    Improve error handling when reading/writing files from/to fuzzers directory.&lt;br&gt;
-    Add SHA-512 Hash payload processor (Issue 2643).&lt;br&gt;
-    Allow to search the fuzzer file names when selecting them.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/fuzz-beta-6.zap</url>
-        <hash>SHA1:b49dea08655edaab20d0c72f706177b288cf3091</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
-        <date>2016-07-14</date>
-        <size>2193035</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_fuzz>
-    
-    <addon>importurls</addon>
-    <addon_importurls>
-        <name>Import files containing URLs</name>
-        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>importurls-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Promoted to beta, updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/importurls-beta-2.zap</url>
-        <hash>SHA1:59cb337708eb12372855391c2b600062167acced</hash>
-        <date>2015-04-13</date>
-        <size>200107</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_importurls>
-    
-    <addon>invoke</addon>
-    <addon_invoke>
-        <name>Invoke Applications</name>
-        <description>Invoke external applications passing context related information such as URLs and parameters</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>invoke-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Allow to invoke the applications in all UI components that show HTTP messages.&lt;br&gt;
-    Allow to manually specify the application path and working directory (Issue 2708).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/invoke-beta-4.zap</url>
-        <hash>SHA1:76d2c426b4afbb23ddd8b514fe8b3f3fbd07d093</hash>
-        <date>2016-08-03</date>
-        <size>283768</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_invoke>
-    
-    <addon>jruby</addon>
-    <addon_jruby>
-        <name>Ruby scripting</name>
-        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jruby-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/jruby-beta-4.zap</url>
-        <hash>SHA1:0759a375e16ef4b01c2bd46c997c3d1de116aa21</hash>
-        <date>2015-04-13</date>
-        <size>22208105</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jruby>
-    
-    <addon>jython</addon>
-    <addon_jython>
-        <name>Python scripting</name>
-        <description>Allows Python to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jython-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/jython-beta-4.zap</url>
-        <hash>SHA1:e89573c9b5fa380a1c4f3fc812b1841105632978</hash>
-        <date>2015-04-13</date>
-        <size>14545042</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jython>
-    
-    <addon>plugnhack</addon>
-    <addon_plugnhack>
-        <name>Plug-n-Hack Configuration</name>
-        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>plugnhack-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Require API key before returning it (Issue 1714)&lt;br&gt;
-    Restrict use of CORS header in pnh (Issue 1716)&lt;br&gt;
-    Auto-scroll when new client events are available (Issue 1664)</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/plugnhack-beta-9.zap</url>
-        <hash>SHA1:9cccd811449afa171b31960d371fd93e9ebb1a89</hash>
-        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
-        <date>2015-08-23</date>
-        <size>507813</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_plugnhack>
-    
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>portscan-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.&lt;br&gt;
-    Do not access view components when view is not initialised (Issue 1617).</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/portscan-beta-7.zap</url>
-        <hash>SHA1:71f8aaece1224fb3859cfe2c56630aacb1ef8f03</hash>
-        <date>2015-12-04</date>
-        <size>602634</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_portscan>
-    
-    <addon>pscanrulesBeta</addon>
-    <addon_pscanrulesBeta>
-        <name>Passive scanner rules (beta)</name>
-        <description>The beta quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>12</version>
-        <file>pscanrulesBeta-beta-12.zap</file>
-        <status>beta</status>
-        <changes>Change (duplicated) scanner ID of Weak Authentication Method, now it's 10105.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/pscanrulesBeta-beta-12.zap</url>
-        <hash>SHA1:083f33e5878237ef45a795f39c8d5d3590260d20</hash>
-        <date>2015-12-04</date>
-        <size>386237</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_pscanrulesBeta>
-    
-    <addon>scripts</addon>
-    <addon_scripts>
-        <name>Script Console</name>
-        <description>Supports all JSR 223 scripting languages</description>
-        <author>ZAP Dev Team</author>
-        <version>15</version>
-        <file>scripts-beta-15.zap</file>
-        <status>beta</status>
-        <changes>Issue 1653: Support context menu key for trees.&lt;br&gt;
-    Updated add-on's info URL.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/scripts-beta-15.zap</url>
-        <hash>SHA1:23d803f7521e268fd3e1eb4f28bc488ded124b32</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
-        <date>2015-08-23</date>
-        <size>505975</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_scripts>
-    
     <addon>sqliplugin</addon>
     <addon_sqliplugin>
         <name>Advanced SQLInjection Scanner</name>
@@ -630,7 +935,21 @@
         <size>104490</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_sqliplugin>
-    
+    <addon>sse</addon>
+    <addon_sse>
+        <name>Server-Sent Events</name>
+        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>sse-alpha-8.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sse-alpha-8.zap</url>
+        <hash>SHA1:a1a04f9a7d05c9713d177b8b069272b1c4ee575a</hash>
+        <date>2015-05-09</date>
+        <size>315877</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_sse>
     <addon>svndigger</addon>
     <addon_svndigger>
         <name>SVN Digger files</name>
@@ -647,7 +966,6 @@
         <size>614833</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_svndigger>
-    
     <addon>tips</addon>
     <addon_tips>
         <name>Tips and Tricks</name>
@@ -663,7 +981,6 @@
         <size>481004</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_tips>
-    
     <addon>tokengen</addon>
     <addon_tokengen>
         <name>Token generation and analysis</name>
@@ -672,15 +989,13 @@
         <version>10</version>
         <file>tokengen-beta-10.zap</file>
         <status>beta</status>
-        <changes>Change active Pause Button to a Play button (Issue 1802).&lt;br&gt;
-	    </changes>
+        <changes>Change active Pause Button to a Play button (Issue 1802).&lt;br&gt;</changes>
         <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/tokengen-beta-10.zap</url>
         <hash>SHA1:10fd7210147c1e9039b9f5bc9b77180fd6fb57a4</hash>
         <date>2015-09-07</date>
         <size>295289</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_tokengen>
-    
     <addon>treetools</addon>
     <addon_treetools>
         <name>TreeTools</name>
@@ -696,7 +1011,37 @@
         <size>16870</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_treetools>
-    
+    <addon>wappalyzer</addon>
+    <addon_wappalyzer>
+        <name>Technology detection using Wappalyzer</name>
+        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>wappalyzer-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for latest wappalyzer data.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/wappalyzer-alpha-6.zap</url>
+        <hash>SHA1:7276442f986ce436bc51f665901281359226b0db</hash>
+        <date>2016-02-08</date>
+        <size>1276840</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_wappalyzer>
+    <addon>websocket</addon>
+    <addon_websocket>
+        <name>WebSockets</name>
+        <description>Allows you to inspect WebSocket communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>websocket-release-10.zap</file>
+        <status>release</status>
+        <changes>Fix issue with length of handshake's url (Issue 2097).&lt;br&gt;
+    Restore fuzzing capabilities (Issue 1905).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/websocket-release-10.zap</url>
+        <hash>SHA1:e323ca749b9aa77040f3366a5924c2a6173e5be1</hash>
+        <date>2015-12-04</date>
+        <size>823387</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_websocket>
     <addon>zest</addon>
     <addon_zest>
         <name>Zest - Graphical Security Scripting Language</name>
@@ -733,415 +1078,4 @@
             </addons>
         </dependencies>
     </addon_zest>
-	
-	<addon>accessControl</addon>
-    <addon_accessControl>
-        <name>Access Control Testing</name>
-        <description>Adds a set of tools for testing access control in web applications.</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>accessControl-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>Initial version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/accessControl-alpha-1.zap</url>
-        <hash>SHA1:92a1bca6711f223e1eaff7e577307d835bcaf9f7</hash>
-        <date>2015-04-13</date>
-        <size>444307</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_accessControl>
-    
-    <addon>amf</addon>
-    <addon_amf>
-        <name>AMF</name>
-        <description>Adds support for AMF messages</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>amf-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First release as an add-on, previously bundled with core.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/amf-alpha-1.zap</url>
-        <hash>SHA1:56e8f859ac538a9b7b1d6d8022cc406f8accbcb1</hash>
-        <date>2015-08-16</date>
-        <size>808303</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_amf>
-    
-    <addon>ascanrulesAlpha</addon>
-    <addon_ascanrulesAlpha>
-        <name>Active scanner rules (alpha)</name>
-        <description>The alpha quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>15</version>
-        <file>ascanrulesAlpha-alpha-15.zap</file>
-        <status>alpha</status>
-        <changes>Update add-on's info URL.&lt;br&gt;
-    Added Integer Overflow scanner.&lt;br&gt;
-    Added new scanner User Agent Fuzzer. The scanner checks for differences in response based on fuzzed User Agent.&lt;br&gt;
-    Slightly improve performance of "Source Code Disclosure - File Inclusion".&lt;br&gt;
-    Demoted LDAP rule due to performance issues</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/ascanrulesAlpha-alpha-15.zap</url>
-        <hash>SHA1:52f9b52561ba82e83ab6808e2a428135ecc7a8ef</hash>
-        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
-        <date>2015-12-04</date>
-        <size>1312312</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_ascanrulesAlpha>
-
-    <addon>browserView</addon>
-    <addon_browserView>
-        <name>Browser View</name>
-        <description>Adds an option to render HTML responses like a browser</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>browserView-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/browserView-alpha-4.zap</url>
-        <hash>SHA1:dc770d05e90b1ca0ea865c828be24532d393e21e</hash>
-        <date>2015-04-13</date>
-        <size>174828</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_browserView>
-
-    <addon>callgraph</addon>
-    <addon_callgraph>
-        <name>Call Graph</name>
-        <description>Allows the user to view a call graph of the selected resources</description>
-        <author>Colm O'Flaherty</author>
-        <version>3</version>
-        <file>callgraph-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/callgraph-alpha-3.zap</url>
-        <hash>SHA1:7e5f464cab9f948f6f84d9c480e48b45b8f0dd84</hash>
-        <date>2015-04-13</date>
-        <size>1143369</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_callgraph>
-
-    <addon>codedx</addon>
-    <addon_codedx>
-        <name>Code Dx Extension</name>
-        <description>includes request and response data in xml reports</description>
-        <author>Code Dx, Inc.</author>
-        <version>2</version>
-        <file>codedx-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Rework HTML tags in reports</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/codedx-alpha-2.zap</url>
-        <hash>SHA1:f3236e638d96e14380e1f89c7c3ca2b6f9b7990e</hash>
-        <date>2015-12-04</date>
-        <size>22196</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_codedx>
-
-    <addon>communityScripts</addon>
-    <addon_communityScripts>
-        <name>Community Scripts</name>
-        <description>Useful ZAP scripts written by the ZAP community.</description>
-        <author>ZAP Community</author>
-        <version>2</version>
-        <file>communityScripts-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Fixed bug which prevents ZAP configs from being saved correctly&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/communityScripts-alpha-2.zap</url>
-        <hash>SHA1:74ac7f864454b32dd6a985d6b169c3f26c77ac88</hash>
-        <info>https://github.com/zaproxy/community-scripts</info>
-        <date>2016-02-17</date>
-        <size>129034</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_communityScripts>
-
-    <addon>customreport</addon>
-    <addon_customreport>
-        <name>CustomReport</name>
-        <description>New HTML report module allows users to customize report content.</description>
-        <author>Chienli Ma</author>
-        <version>1</version>
-        <file>customreport-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/customreport-alpha-1.zap</url>
-        <hash>SHA1:235bc5518455394c0d5081e314fbffeb8638156f</hash>
-        <date>2015-12-04</date>
-        <size>555935</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_customreport>
-
-    <addon>domxss</addon>
-    <addon_domxss>
-        <name>DOM XSS Active scanner rule</name>
-        <description>DOM XSS Active scanner rule</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>domxss-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Change (duplicated) scanner ID, now it's 40026.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/domxss-alpha-2.zap</url>
-        <hash>SHA1:083b18d47649463cb894a4b7f78224ad7eee3499</hash>
-        <date>2015-12-04</date>
-        <size>191683</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>1.*</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_domxss>
-
-    <addon>help_bs_BA</addon>
-    <addon_help_bs_BA>
-        <name>Help - Bosnian</name>
-        <description>Bosnian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>4</version>
-        <file>help_bs_BA-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.4.3</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_bs_BA-alpha-4.zap</url>
-        <hash>SHA1:35c5b1b5f1a5cada187be51b50fda04d9b84edfa</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2015-12-04</date>
-        <size>728733</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_help_bs_BA>
-
-    <addon>help_es_ES</addon>
-    <addon_help_es_ES>
-        <name>Help - Spanish</name>
-        <description>Spanish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>4</version>
-        <file>help_es_ES-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.4.3</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_es_ES-alpha-4.zap</url>
-        <hash>SHA1:e47e9fb0ee21ae2612b4bc16f83b5c504f389442</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2015-12-04</date>
-        <size>731964</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_help_es_ES>
-
-    <addon>help_fr_FR</addon>
-    <addon_help_fr_FR>
-        <name>Help - French</name>
-        <description>French version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>4</version>
-        <file>help_fr_FR-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.4.3</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_fr_FR-alpha-4.zap</url>
-        <hash>SHA1:803e9ff2a6ef6342dcf8b9fe1f8ea5059c98ad90</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2015-12-04</date>
-        <size>728018</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_help_fr_FR>
-
-    <addon>help_ja_JP</addon>
-    <addon_help_ja_JP>
-        <name>Help - Japanese</name>
-        <description>Japanese version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>4</version>
-        <file>help_ja_JP-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.4.3</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/help_ja_JP-alpha-4.zap</url>
-        <hash>SHA1:5981c8e3924145ce2762d87aa2c80b3d036f4acf</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2015-12-04</date>
-        <size>755403</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_help_ja_JP>
-
-    <addon>highlighter</addon>
-    <addon_highlighter>
-        <name>Highlighter</name>
-        <description>Allows you to highlight strings in the request and response tabs.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>highlighter-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/highlighter-alpha-6.zap</url>
-        <hash>SHA1:211f40cedfb7e72e948561bd2c02e7424ddf53de</hash>
-        <date>2015-04-13</date>
-        <size>9562</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_highlighter>
-
-    <addon>httpsInfo</addon>
-    <addon_httpsInfo>
-        <name>HttpsInfo</name>
-        <description>Adds Https status information</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>httpsInfo-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Issue 1978 Uncaught NPE - Fixed.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/httpsInfo-alpha-6.zap</url>
-        <hash>SHA1:08b55236c4a67d68e99db7ed37b291f65edd70c7</hash>
-        <date>2015-12-04</date>
-        <size>51818</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_httpsInfo>
-
-    <addon>importLogFiles</addon>
-    <addon_importLogFiles>
-        <name>Log File Importer</name>
-        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>importLogFiles-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Updated add-on's info URL.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/importLogFiles-alpha-3.zap</url>
-        <hash>SHA1:43308016f687eb673d783425e2bb5279920ca3ce</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
-        <date>2015-09-07</date>
-        <size>151944</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_importLogFiles>
-
-    <addon>pscanrulesAlpha</addon>
-    <addon_pscanrulesAlpha>
-        <name>Passive scanner rules (alpha)</name>
-        <description>The alpha quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>pscanrulesAlpha-alpha-10.zap</file>
-        <status>alpha</status>
-        <changes>XPoweredByHeaderInfoLeakScanner modify evidence (Issue 2575)&lt;br&gt;
-		ContentSecurityPolicyMissingScanner to only check for older CSP headers at Low threshold&lt;br&gt;
-		CacheableScanner: Add other information in attack and remove evidence (Issue 2573)&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesAlpha-alpha-10.zap</url>
-        <hash>SHA1:1fc881177fd0e629c8c0b97480e96cdcd51cb052</hash>
-        <date>2016-06-22</date>
-        <size>1850422</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_pscanrulesAlpha>
-
-    <addon>revisit</addon>
-    <addon_revisit>
-        <name>Revisit</name>
-        <description>Revisit a site at any time in the past using the session history</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>revisit-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/revisit-alpha-1.zap</url>
-        <hash>SHA1:dd656f51d67659486634d14d743cdfabbdcc4b88</hash>
-        <date>2015-10-26</date>
-        <size>82810</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_revisit>
-
-    <addon>saml</addon>
-    <addon_saml>
-        <name>SAML Extension</name>
-        <description>Detect, Show, Edit, Fuzz SAML requests</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>saml-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Internationalise and show 'SAML Actions' menu.&lt;br&gt;
-	Security fixes, to be detailed later.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/saml-alpha-5.zap</url>
-        <hash>SHA1:9d1e9eb975ae2428b99f7e0a88f9cab1c07f0aaa</hash>
-        <info>https://github.com/zaproxy/zaproxy</info>
-        <date>2016-02-05</date>
-        <size>994451</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_saml>
-
-    <addon>sequence</addon>
-    <addon_sequence>
-        <name>Sequence</name>
-        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>sequence-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Updated to latest core changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sequence-alpha-2.zap</url>
-        <hash>SHA1:97ef0d02e5fbc26a82c50b32f93906049c57aafb</hash>
-        <date>2015-09-07</date>
-        <size>35673</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_sequence>
-
-    <addon>sniTerminator</addon>
-    <addon_sniTerminator>
-        <name>SNI Terminator</name>
-        <description>Transparent HTTP proxying</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>sniTerminator-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Update library to work with newer versions of ZAP.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sniTerminator-alpha-4.zap</url>
-        <hash>SHA1:c6e18d4e1fb7d9b1194584f897d6d87bc7226209</hash>
-        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
-        <date>2016-05-30</date>
-        <size>247164</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_sniTerminator>
-
-    <addon>soap</addon>
-    <addon_soap>
-        <name>SOAP Scanner</name>
-        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
-        <author>Alberto (albertov91)</author>
-        <version>2</version>
-        <file>soap-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Fixes a problem where operations under the same location were overwritten. Other minor fixes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/soap-alpha-2.zap</url>
-        <hash>SHA1:c6076ed993bece3ca0b67c4fe308944ecc61c0f4</hash>
-        <date>2015-09-07</date>
-        <size>7282070</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_soap>
-
-    <addon>sse</addon>
-    <addon_sse>
-        <name>Server-Sent Events</name>
-        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>sse-alpha-8.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/sse-alpha-8.zap</url>
-        <hash>SHA1:a1a04f9a7d05c9713d177b8b069272b1c4ee575a</hash>
-        <date>2015-05-09</date>
-        <size>315877</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_sse>
-
-    <addon>wappalyzer</addon>
-    <addon_wappalyzer>
-        <name>Technology detection using Wappalyzer</name>
-        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>wappalyzer-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for latest wappalyzer data.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.4/wappalyzer-alpha-6.zap</url>
-        <hash>SHA1:7276442f986ce436bc51f665901281359226b0db</hash>
-        <date>2016-02-08</date>
-        <size>1276840</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_wappalyzer>
-	
 </ZAP>

--- a/ZapVersions-2.5.xml
+++ b/ZapVersions-2.5.xml
@@ -1,37 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
-	
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
+    <addon>accessControl</addon>
+    <addon_accessControl>
+        <name>Access Control Testing</name>
+        <description>Adds a set of tools for testing access control in web applications.</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>accessControl-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Fix an exception when cancelling the "Save" access control report dialogue.&lt;br&gt;
+	Do not allow to dynamically uninstall, not yet supported.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/accessControl-alpha-2.zap</url>
+        <hash>SHA1:967be37f73670af78a04deca1429dec4d8ff9231</hash>
+        <date>2016-06-02</date>
+        <size>495908</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_accessControl>
+    <addon>alertFilters</addon>
+    <addon_alertFilters>
+        <name>Context Alert Filters</name>
+        <description>Allows you to automate the changing of alert risk levels.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>alertFilters-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Various minor UI improvements&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertFilters-beta-3.zap</url>
+        <hash>SHA1:1d574afee5421395684cc3c733c5892ef9d1d64d</hash>
+        <date>2016-06-02</date>
+        <size>270471</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_alertFilters>
+    <addon>alertReport</addon>
+    <addon_alertReport>
+        <name>Report alert generator</name>
+        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
+        <author>Talsoft SRL</author>
+        <version>14</version>
+        <file>alertReport-beta-14.zap</file>
+        <status>beta</status>
+        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
+	Include Alert's evidence in report of ODT format.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertReport-beta-14.zap</url>
+        <hash>SHA1:d5f2a410eafec455e4b1051eb68d7d6560c68be5</hash>
+        <info>http://www.talsoft.com.ar</info>
+        <date>2016-06-02</date>
+        <size>9712171</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_alertReport>
+    <addon>amf</addon>
+    <addon_amf>
+        <name>AMF</name>
+        <description>Adds support for AMF messages</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>amf-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First release as an add-on, previously bundled with core.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/amf-alpha-1.zap</url>
+        <hash>SHA1:7193f6b263f5a2c2352c2be8963d42944b4ae05f</hash>
+        <date>2016-06-02</date>
+        <size>808609</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_amf>
     <addon>ascanrules</addon>
     <addon_ascanrules>
         <name>Active scanner rules</name>
@@ -50,7 +111,167 @@
         <size>551792</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_ascanrules>
-    
+    <addon>ascanrulesAlpha</addon>
+    <addon_ascanrulesAlpha>
+        <name>Active scanner rules (alpha)</name>
+        <description>The alpha quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>18</version>
+        <file>ascanrulesAlpha-alpha-18.zap</file>
+        <status>alpha</status>
+        <changes>Added Apache Range Header DoS (CVE-2011-3192) scanner.&lt;br&gt;
+	Fix exception when raising a "Source Code Disclosure - File Inclusion" alert.&lt;br&gt;
+	Adjust log levels of some scanners, from INFO to DEBUG.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/ascanrulesAlpha-alpha-18.zap</url>
+        <hash>SHA1:7e14d4fe67389fa2d230b607b5e5aa7dd8b8c31f</hash>
+        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
+        <date>2016-10-24</date>
+        <size>1333963</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_ascanrulesAlpha>
+    <addon>ascanrulesBeta</addon>
+    <addon_ascanrulesBeta>
+        <name>Active scanner rules (beta)</name>
+        <description>The beta quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>21</version>
+        <file>ascanrulesBeta-beta-21.zap</file>
+        <status>beta</status>
+        <changes>Support changing the length of time used in timing attacks via config options.&lt;br&gt;
+	Support ignoring specified forms when checking for CSRF vulnerabilities.&lt;br&gt;
+	Do not attempt to parse empty cross domain policy files.&lt;br&gt;
+	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.&lt;br&gt;
+	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.&lt;br&gt;
+	Respect OS techs included when scanning with Remote Code Execution - CVE-2012-1823.&lt;br&gt;
+	Adjust log levels of some scanners, from INFO to DEBUG.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/ascanrulesBeta-beta-21.zap</url>
+        <hash>SHA1:0c59e05f3c153958fa23b3a5f05a7033c61b6a78</hash>
+        <date>2016-10-24</date>
+        <size>2714237</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_ascanrulesBeta>
+    <addon>authstats</addon>
+    <addon_authstats>
+        <name>Authentication Statistics</name>
+        <description>Records logged in/out statistics for all contexts in scope.</description>
+        <author>ZAP Core Team</author>
+        <version>1</version>
+        <file>authstats-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First version&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/authstats-alpha-1.zap</url>
+        <hash>SHA1:c00d7e572faba04ff1262bcc04406599a8b20ffd</hash>
+        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAuthstatsAuthStats</info>
+        <date>2016-08-16</date>
+        <size>11605</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_authstats>
+    <addon>beanshell</addon>
+    <addon_beanshell>
+        <name>BeanShell Console</name>
+        <description>Provides a BeanShell Console</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>beanshell-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/beanshell-beta-5.zap</url>
+        <hash>SHA1:1fc34a12180cd700cc6fad2236641936cece8cdc</hash>
+        <date>2016-06-02</date>
+        <size>562333</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_beanshell>
+    <addon>browserView</addon>
+    <addon_browserView>
+        <name>Browser View</name>
+        <description>Adds an option to render HTML responses like a browser</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>browserView-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/browserView-alpha-4.zap</url>
+        <hash>SHA1:d48e7768ecac5bb5e12d6e7c36907bfbf95ea46d</hash>
+        <date>2016-06-02</date>
+        <size>180584</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_browserView>
+    <addon>bruteforce</addon>
+    <addon_bruteforce>
+        <name>Forced Browse</name>
+        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>bruteforce-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Adding request count on Forced browser tab as specified on issue #1873</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/bruteforce-beta-5.zap</url>
+        <hash>SHA1:c41f63171add4112602a800f13296ca6b7e296ae</hash>
+        <date>2016-06-02</date>
+        <size>974247</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_bruteforce>
+    <addon>bugtracker</addon>
+    <addon_bugtracker>
+        <name>Bug Tracker</name>
+        <description>Bug Tracker extension.</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>bugtracker-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/bugtracker-alpha-1.zap</url>
+        <hash>SHA1:3c2ae880b9d942fe817483ac515371f5ff2e47c2</hash>
+        <date>2016-08-25</date>
+        <size>1736016</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_bugtracker>
+    <addon>callgraph</addon>
+    <addon_callgraph>
+        <name>Call Graph</name>
+        <description>Allows the user to view a call graph of the selected resources</description>
+        <author>Colm O'Flaherty</author>
+        <version>3</version>
+        <file>callgraph-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/callgraph-alpha-3.zap</url>
+        <hash>SHA1:d72894ec70bd21f30026154c29243d17983b36e9</hash>
+        <date>2016-06-02</date>
+        <size>1157575</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_callgraph>
+    <addon>codedx</addon>
+    <addon_codedx>
+        <name>Code Dx Extension</name>
+        <description>Includes request and response data in XML reports and provides the ability to upload reports directly to a Code Dx server</description>
+        <author>Code Dx, Inc.</author>
+        <version>5</version>
+        <file>codedx-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Add an upload to Code Dx option.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/codedx-alpha-5.zap</url>
+        <hash>SHA1:fad5d14acd070d6ab2b7baae7092a5f75f5b6a8c</hash>
+        <date>2017-04-18</date>
+        <size>1185698</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_codedx>
+    <addon>communityScripts</addon>
+    <addon_communityScripts>
+        <name>Community Scripts</name>
+        <description>Useful ZAP scripts written by the ZAP community.</description>
+        <author>ZAP Community</author>
+        <version>3</version>
+        <file>communityScripts-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Updated with the latest scripts for 2.5.0&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/communityScripts-alpha-3.zap</url>
+        <hash>SHA1:f1c2e0af4cf4500b9d0656723316a6f0e806f668</hash>
+        <info>https://github.com/zaproxy/community-scripts</info>
+        <date>2016-06-02</date>
+        <size>134107</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_communityScripts>
     <addon>coreLang</addon>
     <addon_coreLang>
         <name>Core Language Files</name>
@@ -67,7 +288,56 @@
         <size>2715140</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_coreLang>
-    
+    <addon>cspscanner</addon>
+    <addon_cspscanner>
+        <name>Content Security Policy Scanner</name>
+        <description>Content Security Policy (CSP) Scanner</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>cspscanner-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Fixed missing error and warning messages.&lt;br&gt;
+		Added evidence.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/cspscanner-alpha-4.zap</url>
+        <hash>SHA1:1d672d3575e395c5bd466274979338a5ece2d965</hash>
+        <date>2017-07-27</date>
+        <size>112917</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_cspscanner>
+    <addon>customreport</addon>
+    <addon_customreport>
+        <name>CustomReport</name>
+        <description>New HTML report module allows users to customize report content.</description>
+        <author>Chienli Ma</author>
+        <version>2</version>
+        <file>customreport-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/customreport-alpha-2.zap</url>
+        <hash>SHA1:fe8f172a879e5372d040449973ac7a1a133eafd5</hash>
+        <date>2016-06-02</date>
+        <size>557158</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_customreport>
+    <addon>diff</addon>
+    <addon_diff>
+        <name>Diff</name>
+        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>diff-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Do not add line break tags to resultant diff (Issue 1571)&lt;br&gt;
+	Automatically close the diff dialogue when uninstalling.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/diff-beta-6.zap</url>
+        <hash>SHA1:500ea3fe0fe3ad751a11dc9d5b24391d12171281</hash>
+        <date>2016-06-02</date>
+        <size>221791</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_diff>
     <addon>directorylistv1</addon>
     <addon_directorylistv1>
         <name>Directory List v1.0</name>
@@ -85,7 +355,6 @@
         <size>847617</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv1>
-    
     <addon>directorylistv2_3</addon>
     <addon_directorylistv2_3>
         <name>Directory List v2.3</name>
@@ -103,7 +372,6 @@
         <size>8608732</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3>
-    
     <addon>directorylistv2_3_lc</addon>
     <addon_directorylistv2_3_lc>
         <name>Directory List v2.3 LC</name>
@@ -120,7 +388,29 @@
         <size>7454765</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3_lc>
-
+    <addon>domxss</addon>
+    <addon_domxss>
+        <name>DOM XSS Active scanner rule</name>
+        <description>DOM XSS Active scanner rule</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>domxss-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Skip the scanner if not able to start Firefox.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/domxss-alpha-3.zap</url>
+        <hash>SHA1:b86bdc8d25461bf0922a699d84d635e1bc8dc9a0</hash>
+        <date>2016-10-24</date>
+        <size>192724</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>1.*</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_domxss>
     <addon>exportreport</addon>
     <addon_exportreport>
         <name>Export Report</name>
@@ -136,7 +426,24 @@
         <size>5841253</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_exportreport>
-    
+    <addon>fuzz</addon>
+    <addon_fuzz>
+        <name>AdvFuzzer</name>
+        <description>Advanced fuzzer for manual testing</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <semver>2.0.1</semver>
+        <file>fuzz-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Fix exception during the unload of the add-on, when in daemon mode.&lt;br&gt;
+    Update Content-Length for all request methods, not just POST (Issue 2766).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/fuzz-beta-7.zap</url>
+        <hash>SHA1:b1fa365be40addf37c6d9851996f7772678ddabe</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
+        <date>2016-09-05</date>
+        <size>2223603</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_fuzz>
     <addon>fuzzdb</addon>
     <addon_fuzzdb>
         <name>FuzzDB files</name>
@@ -153,7 +460,6 @@
         <size>5626766</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_fuzzdb>
-    
     <addon>gettingStarted</addon>
     <addon_gettingStarted>
         <name>Getting Started with ZAP Guide</name>
@@ -169,7 +475,6 @@
         <size>473681</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_gettingStarted>
-    
     <addon>help</addon>
     <addon_help>
         <name>Help - English</name>
@@ -186,7 +491,70 @@
         <size>739293</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_help>
-
+    <addon>help_bs_BA</addon>
+    <addon_help_bs_BA>
+        <name>Help - Bosnian</name>
+        <description>Bosnian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>5</version>
+        <file>help_bs_BA-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.5.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_bs_BA-alpha-5.zap</url>
+        <hash>SHA1:aa7ed9aa95bff1b2d1aeb547ff6cab7d5a37bef6</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2016-06-02</date>
+        <size>756583</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_help_bs_BA>
+    <addon>help_es_ES</addon>
+    <addon_help_es_ES>
+        <name>Help - Spanish</name>
+        <description>Spanish version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>5</version>
+        <file>help_es_ES-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.5.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_es_ES-alpha-5.zap</url>
+        <hash>SHA1:b25a9f3e4db5eb41c19647ec623750043d26325c</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2016-06-02</date>
+        <size>760182</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_help_es_ES>
+    <addon>help_fr_FR</addon>
+    <addon_help_fr_FR>
+        <name>Help - French</name>
+        <description>French version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>5</version>
+        <file>help_fr_FR-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.5.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_fr_FR-alpha-5.zap</url>
+        <hash>SHA1:423675291345b964ca0aeda95550ffd978071f6f</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2016-06-02</date>
+        <size>757459</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_help_fr_FR>
+    <addon>help_ja_JP</addon>
+    <addon_help_ja_JP>
+        <name>Help - Japanese</name>
+        <description>Japanese version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>5</version>
+        <file>help_ja_JP-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.5.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_ja_JP-alpha-5.zap</url>
+        <hash>SHA1:33bca35847c84da63a2522fb26c6679cf870211f</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2016-06-02</date>
+        <size>783581</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_help_ja_JP>
     <addon>help_pt_BR</addon>
     <addon_help_pt_BR>
         <name>Help - Portuguese, Brazilian</name>
@@ -203,7 +571,228 @@
         <size>797933</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_help_pt_BR>
-    
+    <addon>highlighter</addon>
+    <addon_highlighter>
+        <name>Highlighter</name>
+        <description>Allows you to highlight strings in the request and response tabs.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>highlighter-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/highlighter-alpha-6.zap</url>
+        <hash>SHA1:ebc48b0880ff7862839ae0158de9ddb038218735</hash>
+        <date>2016-06-02</date>
+        <size>9568</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_highlighter>
+    <addon>httpsInfo</addon>
+    <addon_httpsInfo>
+        <name>HttpsInfo</name>
+        <description>Displays HTTPS status information.</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>httpsInfo-alpha-7.zap</file>
+        <status>alpha</status>
+        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;
+	Issue 758 - General re-working of the extension.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/httpsInfo-alpha-7.zap</url>
+        <hash>SHA1:5fa83cf1adfe80695fbf8209b5cad4b19f2f6787</hash>
+        <date>2016-06-02</date>
+        <size>48860</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_httpsInfo>
+    <addon>importLogFiles</addon>
+    <addon_importLogFiles>
+        <name>Log File Importer</name>
+        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>importLogFiles-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Use API actions when importing files.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importLogFiles-alpha-4.zap</url>
+        <hash>SHA1:ed557f0caf1e7c630532d9171f13f8afaa99be30</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
+        <date>2017-05-05</date>
+        <size>152363</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_importLogFiles>
+    <addon>importurls</addon>
+    <addon_importurls>
+        <name>Import files containing URLs</name>
+        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>importurls-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Issue 1643: Add an API end point for importing URLs from file.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importurls-beta-3.zap</url>
+        <hash>SHA1:5cc6bf40f8a371b217c12890ebc6bea3d93e667e</hash>
+        <date>2017-05-12</date>
+        <size>215827</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_importurls>
+    <addon>invoke</addon>
+    <addon_invoke>
+        <name>Invoke Applications</name>
+        <description>Invoke external applications passing context related information such as URLs and parameters</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>invoke-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Properly split application arguments.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/invoke-beta-6.zap</url>
+        <hash>SHA1:ef5cd83668332fc18b7df07eb2b104960310f2cf</hash>
+        <date>2017-04-03</date>
+        <size>289967</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_invoke>
+    <addon>jruby</addon>
+    <addon_jruby>
+        <name>Ruby scripting</name>
+        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jruby-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/jruby-beta-4.zap</url>
+        <hash>SHA1:d3c2f567a627ccf0f51eaff17afb8450871ad102</hash>
+        <date>2016-06-02</date>
+        <size>22467350</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jruby>
+    <addon>jxbrowser</addon>
+    <addon_jxbrowser>
+        <name>JxBrowser (core)</name>
+        <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jxbrowser-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Added button for selecting URL from Sites tree.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowser-alpha-4.zap</url>
+        <hash>SHA1:b8f0253f88c2e15ef7d2552ac8aac7a0f62d728a</hash>
+        <date>2017-05-05</date>
+        <size>1411594</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_jxbrowser>
+    <addon>jxbrowserlinux32</addon>
+    <addon_jxbrowserlinux32>
+        <name>JxBrowser (Linux 32)</name>
+        <description>An embedded browser based on Chromium, Linux 32 specific</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>jxbrowserlinux32-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux32-alpha-2.zap</url>
+        <hash>SHA1:dbed700fb82554e25e26a73fdac1ad337fb2b5ce</hash>
+        <date>2017-04-25</date>
+        <size>46399267</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverlinux</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserlinux32>
+    <addon>jxbrowserlinux64</addon>
+    <addon_jxbrowserlinux64>
+        <name>JxBrowser (Linux 64)</name>
+        <description>An embedded browser based on Chromium, Linux 64 specific</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>jxbrowserlinux64-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux64-alpha-2.zap</url>
+        <hash>SHA1:49d07afb501d171ce7a04e03876d60951c504349</hash>
+        <date>2017-04-25</date>
+        <size>46037789</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverlinux</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserlinux64>
+    <addon>jxbrowsermacos</addon>
+    <addon_jxbrowsermacos>
+        <name>JxBrowser (Mac OS)</name>
+        <description>An embedded browser based on Chromium, Mac OS specific</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>jxbrowsermacos-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowsermacos-alpha-2.zap</url>
+        <hash>SHA1:9c949adbc339c269dc4880d4b3bf018693914878</hash>
+        <date>2017-04-25</date>
+        <size>51499781</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdrivermacos</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowsermacos>
+    <addon>jxbrowserwindows</addon>
+    <addon_jxbrowserwindows>
+        <name>JxBrowser (Windows)</name>
+        <description>An embedded browser based on Chromium, Windows specific</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>jxbrowserwindows-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserwindows-alpha-2.zap</url>
+        <hash>SHA1:efb07bab671efb6ed955107a799bf6ade3a4d15f</hash>
+        <date>2017-04-25</date>
+        <size>35906181</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverwindows</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserwindows>
+    <addon>jython</addon>
+    <addon_jython>
+        <name>Python scripting</name>
+        <description>Allows Python to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>jython-beta-5.zap</file>
+        <status>beta</status>
+        <changes>add the python module path interface</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/jython-beta-5.zap</url>
+        <hash>SHA1:439e476d56c03e06511305863fda8cb462d97c3f</hash>
+        <date>2017-01-10</date>
+        <size>14692630</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jython>
     <addon>onlineMenu</addon>
     <addon_onlineMenu>
         <name>Online menus</name>
@@ -221,7 +810,55 @@
         <size>198475</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_onlineMenu>
-    
+    <addon>openapi</addon>
+    <addon_openapi>
+        <name>OpenAPI Support</name>
+        <description>Imports and spiders Open API definitions.</description>
+        <author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
+        <version>5</version>
+        <file>openapi-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Run synchronously and return any warnings when importing via API or cmdline.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/openapi-alpha-5.zap</url>
+        <hash>SHA1:10e9d322efce95128647d1760957a94811c0e3a3</hash>
+        <date>2017-05-05</date>
+        <size>2918104</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_openapi>
+    <addon>plugnhack</addon>
+    <addon_plugnhack>
+        <name>Plug-n-Hack Configuration</name>
+        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>plugnhack-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Require API key before returning it (Issue 1714)&lt;br&gt;
+	Restrict use of CORS header in pnh (Issue 1716)&lt;br&gt;
+	Auto-scroll when new client events are available (Issue 1664)</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/plugnhack-beta-9.zap</url>
+        <hash>SHA1:a731c6b82605e4e94a4878fcbd5f8b2cb8c19c9e</hash>
+        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
+        <date>2016-06-02</date>
+        <size>495129</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_plugnhack>
+    <addon>portscan</addon>
+    <addon_portscan>
+        <name>Port Scanner</name>
+        <description>Allows to port scan a target server</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>portscan-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.&lt;br&gt;
+	Do not access view components when view is not initialised (Issue 1617).</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/portscan-beta-7.zap</url>
+        <hash>SHA1:b6d852e021a286fede9da65b5f3ad020c60ed42e</hash>
+        <date>2016-06-02</date>
+        <size>602881</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_portscan>
     <addon>pscanrules</addon>
     <addon_pscanrules>
         <name>Passive scanner rules</name>
@@ -239,7 +876,36 @@
         <size>458352</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_pscanrules>
-    
+    <addon>pscanrulesAlpha</addon>
+    <addon_pscanrulesAlpha>
+        <name>Passive scanner rules (alpha)</name>
+        <description>The alpha quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>13</version>
+        <file>pscanrulesAlpha-alpha-13.zap</file>
+        <status>alpha</status>
+        <changes>Issue 3148: Only report HSTS on plain HTTP issue at Low threshold.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesAlpha-alpha-13.zap</url>
+        <hash>SHA1:e62fb2955140ca56ca6b11ad1454b088578e5fe4</hash>
+        <date>2017-01-18</date>
+        <size>1944233</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_pscanrulesAlpha>
+    <addon>pscanrulesBeta</addon>
+    <addon_pscanrulesBeta>
+        <name>Passive scanner rules (beta)</name>
+        <description>The beta quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>15</version>
+        <file>pscanrulesBeta-beta-15.zap</file>
+        <status>beta</status>
+        <changes>Support security annotations for forms that dont need anti-CSRF tokens.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesBeta-beta-15.zap</url>
+        <hash>SHA1:95bf040c81bf107125e2bdaae7a1596c6715d2b6</hash>
+        <date>2017-01-18</date>
+        <size>528262</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_pscanrulesBeta>
     <addon>quickstart</addon>
     <addon_quickstart>
         <name>Quick Start</name>
@@ -256,7 +922,35 @@
         <size>337698</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_quickstart>
-    
+    <addon>replacer</addon>
+    <addon_replacer>
+        <name>Replacer</name>
+        <description>Easy way to replace strings in requests and responses.</description>
+        <author>ZAP Dev Team</author>
+        <version>1</version>
+        <file>replacer-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/replacer-alpha-1.zap</url>
+        <hash>SHA1:f33439b3c89edb394e42728eb4edeed1d5bea9b6</hash>
+        <date>2017-02-01</date>
+        <size>36527</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_replacer>
+    <addon>requester</addon>
+    <addon_requester>
+        <name>Requester</name>
+        <description>Request numbered panel.</description>
+        <author>Surikato</author>
+        <version>1</version>
+        <file>requester-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/requester-alpha-1.zap</url>
+        <hash>SHA1:3f43ac40b5b6225ebdc918df0b14cd53f0e7e8a2</hash>
+        <date>2016-06-02</date>
+        <size>40411</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_requester>
     <addon>reveal</addon>
     <addon_reveal>
         <name>Reveal</name>
@@ -272,7 +966,37 @@
         <size>221496</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_reveal>
-    
+    <addon>revisit</addon>
+    <addon_revisit>
+        <name>Revisit</name>
+        <description>Revisit a site at any time in the past using the session history</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>revisit-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/revisit-alpha-2.zap</url>
+        <hash>SHA1:84087ce758254bc515160b458bcf5c2c82773641</hash>
+        <date>2016-06-02</date>
+        <size>279982</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_revisit>
+    <addon>saml</addon>
+    <addon_saml>
+        <name>SAML Extension</name>
+        <description>Detect, Show, Edit, Fuzz SAML requests</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>saml-alpha-7.zap</file>
+        <status>alpha</status>
+        <changes>Minor code change to work with ZAP 2.5.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/saml-alpha-7.zap</url>
+        <hash>SHA1:47e830cfffbe0742440f9923356ed73f3e817074</hash>
+        <info>https://github.com/zaproxy/zaproxy</info>
+        <date>2017-11-24</date>
+        <size>997657</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_saml>
     <addon>saverawmessage</addon>
     <addon_saverawmessage>
         <name>Save Raw Message</name>
@@ -288,7 +1012,22 @@
         <size>27005</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_saverawmessage>
-    
+    <addon>scripts</addon>
+    <addon_scripts>
+        <name>Script Console</name>
+        <description>Supports all JSR 223 scripting languages</description>
+        <author>ZAP Dev Team</author>
+        <version>17</version>
+        <file>scripts-beta-17.zap</file>
+        <status>beta</status>
+        <changes>Discard undoable edits after setting a script (Issue 2675).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/scripts-beta-17.zap</url>
+        <hash>SHA1:2807956b3942d153d0de04c4c7b9585094e52b17</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
+        <date>2016-09-07</date>
+        <size>499749</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_scripts>
     <addon>selenium</addon>
     <addon_selenium>
         <name>Selenium</name>
@@ -305,7 +1044,56 @@
         <size>31341269</size>
         <not-before-version>2.4.3</not-before-version>
     </addon_selenium>
-
+    <addon>sequence</addon>
+    <addon_sequence>
+        <name>Sequence</name>
+        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>sequence-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Allow to dynamically unload the add-on.&lt;br&gt;
+	Other code changes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sequence-alpha-3.zap</url>
+        <hash>SHA1:73f8e7a72f29b5c9ae26e076ddfb8cfeec64a6c9</hash>
+        <date>2016-06-02</date>
+        <size>37514</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_sequence>
+    <addon>sniTerminator</addon>
+    <addon_sniTerminator>
+        <name>SNI Terminator</name>
+        <description>Transparent HTTP proxying</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>sniTerminator-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Update library to work with newer versions of ZAP.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sniTerminator-alpha-4.zap</url>
+        <hash>SHA1:aa38bb7f929d6d7b54ba4445a9a6c1c276951472</hash>
+        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
+        <date>2016-06-02</date>
+        <size>247164</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_sniTerminator>
+    <addon>soap</addon>
+    <addon_soap>
+        <name>SOAP Scanner</name>
+        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
+        <author>Alberto (albertov91) + ZAP Core team</author>
+        <version>3</version>
+        <file>soap-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Added API, help and other minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/soap-alpha-3.zap</url>
+        <hash>SHA1:c02815ca249e8d2736d9e66498bfe7d43ed0d464</hash>
+        <date>2017-03-31</date>
+        <size>7337575</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_soap>
     <addon>spiderAjax</addon>
     <addon_spiderAjax>
         <name>Ajax Spider</name>
@@ -338,282 +1126,6 @@
             </addons>
         </dependencies>
     </addon_spiderAjax>
-    
-    <addon>websocket</addon>
-    <addon_websocket>
-        <name>WebSockets</name>
-        <description>Allows you to inspect WebSocket communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>websocket-release-11.zap</file>
-        <status>release</status>
-        <changes>Unload WebSockets components during uninstallation.&lt;br&gt;
-	Use hostname/port of the handshake message to build the name of the channel.&lt;br&gt;
-	Adjust log levels, from INFO to DEBUG.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/websocket-release-11.zap</url>
-        <hash>SHA1:87e11bdda6b5d313ade2c90f920a6604b17efb95</hash>
-        <date>2016-06-02</date>
-        <size>779268</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_websocket>
-
-    <addon>alertFilters</addon>
-    <addon_alertFilters>
-        <name>Context Alert Filters</name>
-        <description>Allows you to automate the changing of alert risk levels.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>alertFilters-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Various minor UI improvements&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertFilters-beta-3.zap</url>
-        <hash>SHA1:1d574afee5421395684cc3c733c5892ef9d1d64d</hash>
-        <date>2016-06-02</date>
-        <size>270471</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_alertFilters>
-    
-    <addon>alertReport</addon>
-    <addon_alertReport>
-        <name>Report alert generator</name>
-        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
-        <author>Talsoft SRL</author>
-        <version>14</version>
-        <file>alertReport-beta-14.zap</file>
-        <status>beta</status>
-        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
-	Include Alert's evidence in report of ODT format.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertReport-beta-14.zap</url>
-        <hash>SHA1:d5f2a410eafec455e4b1051eb68d7d6560c68be5</hash>
-        <info>http://www.talsoft.com.ar</info>
-        <date>2016-06-02</date>
-        <size>9712171</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_alertReport>
-    
-    <addon>ascanrulesBeta</addon>
-    <addon_ascanrulesBeta>
-        <name>Active scanner rules (beta)</name>
-        <description>The beta quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>21</version>
-        <file>ascanrulesBeta-beta-21.zap</file>
-        <status>beta</status>
-        <changes>Support changing the length of time used in timing attacks via config options.&lt;br&gt;
-	Support ignoring specified forms when checking for CSRF vulnerabilities.&lt;br&gt;
-	Do not attempt to parse empty cross domain policy files.&lt;br&gt;
-	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.&lt;br&gt;
-	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.&lt;br&gt;
-	Respect OS techs included when scanning with Remote Code Execution - CVE-2012-1823.&lt;br&gt;
-	Adjust log levels of some scanners, from INFO to DEBUG.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/ascanrulesBeta-beta-21.zap</url>
-        <hash>SHA1:0c59e05f3c153958fa23b3a5f05a7033c61b6a78</hash>
-        <date>2016-10-24</date>
-        <size>2714237</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_ascanrulesBeta>
-    
-    <addon>beanshell</addon>
-    <addon_beanshell>
-        <name>BeanShell Console</name>
-        <description>Provides a BeanShell Console</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>beanshell-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/beanshell-beta-5.zap</url>
-        <hash>SHA1:1fc34a12180cd700cc6fad2236641936cece8cdc</hash>
-        <date>2016-06-02</date>
-        <size>562333</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_beanshell>
-    
-    <addon>bruteforce</addon>
-    <addon_bruteforce>
-        <name>Forced Browse</name>
-        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>bruteforce-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Adding request count on Forced browser tab as specified on issue #1873</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/bruteforce-beta-5.zap</url>
-        <hash>SHA1:c41f63171add4112602a800f13296ca6b7e296ae</hash>
-        <date>2016-06-02</date>
-        <size>974247</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_bruteforce>
-    
-    <addon>diff</addon>
-    <addon_diff>
-        <name>Diff</name>
-        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>diff-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Do not add line break tags to resultant diff (Issue 1571)&lt;br&gt;
-	Automatically close the diff dialogue when uninstalling.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/diff-beta-6.zap</url>
-        <hash>SHA1:500ea3fe0fe3ad751a11dc9d5b24391d12171281</hash>
-        <date>2016-06-02</date>
-        <size>221791</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_diff>
-    
-    <addon>fuzz</addon>
-    <addon_fuzz>
-        <name>AdvFuzzer</name>
-        <description>Advanced fuzzer for manual testing</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <semver>2.0.1</semver>
-        <file>fuzz-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Fix exception during the unload of the add-on, when in daemon mode.&lt;br&gt;
-    Update Content-Length for all request methods, not just POST (Issue 2766).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/fuzz-beta-7.zap</url>
-        <hash>SHA1:b1fa365be40addf37c6d9851996f7772678ddabe</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
-        <date>2016-09-05</date>
-        <size>2223603</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_fuzz>
-    
-    <addon>importurls</addon>
-    <addon_importurls>
-        <name>Import files containing URLs</name>
-        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>importurls-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Issue 1643: Add an API end point for importing URLs from file.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importurls-beta-3.zap</url>
-        <hash>SHA1:5cc6bf40f8a371b217c12890ebc6bea3d93e667e</hash>
-        <date>2017-05-12</date>
-        <size>215827</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_importurls>
-    
-    <addon>invoke</addon>
-    <addon_invoke>
-        <name>Invoke Applications</name>
-        <description>Invoke external applications passing context related information such as URLs and parameters</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>invoke-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Properly split application arguments.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/invoke-beta-6.zap</url>
-        <hash>SHA1:ef5cd83668332fc18b7df07eb2b104960310f2cf</hash>
-        <date>2017-04-03</date>
-        <size>289967</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_invoke>
-    
-    <addon>jruby</addon>
-    <addon_jruby>
-        <name>Ruby scripting</name>
-        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jruby-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/jruby-beta-4.zap</url>
-        <hash>SHA1:d3c2f567a627ccf0f51eaff17afb8450871ad102</hash>
-        <date>2016-06-02</date>
-        <size>22467350</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jruby>
-    
-    <addon>jython</addon>
-    <addon_jython>
-        <name>Python scripting</name>
-        <description>Allows Python to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>jython-beta-5.zap</file>
-        <status>beta</status>
-        <changes>add the python module path interface</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/jython-beta-5.zap</url>
-        <hash>SHA1:439e476d56c03e06511305863fda8cb462d97c3f</hash>
-        <date>2017-01-10</date>
-        <size>14692630</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jython>
-    
-    <addon>plugnhack</addon>
-    <addon_plugnhack>
-        <name>Plug-n-Hack Configuration</name>
-        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>plugnhack-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Require API key before returning it (Issue 1714)&lt;br&gt;
-	Restrict use of CORS header in pnh (Issue 1716)&lt;br&gt;
-	Auto-scroll when new client events are available (Issue 1664)</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/plugnhack-beta-9.zap</url>
-        <hash>SHA1:a731c6b82605e4e94a4878fcbd5f8b2cb8c19c9e</hash>
-        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
-        <date>2016-06-02</date>
-        <size>495129</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_plugnhack>
-    
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>portscan-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.&lt;br&gt;
-	Do not access view components when view is not initialised (Issue 1617).</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/portscan-beta-7.zap</url>
-        <hash>SHA1:b6d852e021a286fede9da65b5f3ad020c60ed42e</hash>
-        <date>2016-06-02</date>
-        <size>602881</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_portscan>
-    
-    <addon>pscanrulesBeta</addon>
-    <addon_pscanrulesBeta>
-        <name>Passive scanner rules (beta)</name>
-        <description>The beta quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>15</version>
-        <file>pscanrulesBeta-beta-15.zap</file>
-        <status>beta</status>
-        <changes>Support security annotations for forms that dont need anti-CSRF tokens.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesBeta-beta-15.zap</url>
-        <hash>SHA1:95bf040c81bf107125e2bdaae7a1596c6715d2b6</hash>
-        <date>2017-01-18</date>
-        <size>528262</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_pscanrulesBeta>
-    
-    <addon>scripts</addon>
-    <addon_scripts>
-        <name>Script Console</name>
-        <description>Supports all JSR 223 scripting languages</description>
-        <author>ZAP Dev Team</author>
-        <version>17</version>
-        <file>scripts-beta-17.zap</file>
-        <status>beta</status>
-        <changes>Discard undoable edits after setting a script (Issue 2675).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/scripts-beta-17.zap</url>
-        <hash>SHA1:2807956b3942d153d0de04c4c7b9585094e52b17</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
-        <date>2016-09-07</date>
-        <size>499749</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_scripts>
-    
     <addon>sqliplugin</addon>
     <addon_sqliplugin>
         <name>Advanced SQLInjection Scanner</name>
@@ -629,7 +1141,20 @@
         <size>104490</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_sqliplugin>
-    
+    <addon>sse</addon>
+    <addon_sse>
+        <name>Server-Sent Events</name>
+        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>sse-alpha-9.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sse-alpha-9.zap</url>
+        <hash>SHA1:c642ed5fa03bc2c7840c722baf9dc9d842197e9d</hash>
+        <date>2016-06-02</date>
+        <size>331696</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_sse>
     <addon>svndigger</addon>
     <addon_svndigger>
         <name>SVN Digger files</name>
@@ -646,7 +1171,6 @@
         <size>614846</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_svndigger>
-    
     <addon>tips</addon>
     <addon_tips>
         <name>Tips and Tricks</name>
@@ -662,7 +1186,20 @@
         <size>497063</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_tips>
-    
+    <addon>tlsdebug</addon>
+    <addon_tlsdebug>
+        <name>TLS Debug</name>
+        <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
+        <author>P.M.J. Roth</author>
+        <version>1</version>
+        <file>tlsdebug-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/tlsdebug-alpha-1.zap</url>
+        <hash>SHA1:0b987f507e0219817ba012c38df890c862ce0ea5</hash>
+        <date>2016-11-02</date>
+        <size>22114</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_tlsdebug>
     <addon>tokengen</addon>
     <addon_tokengen>
         <name>Token generation and analysis</name>
@@ -678,7 +1215,6 @@
         <size>241229</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_tokengen>
-    
     <addon>treetools</addon>
     <addon_treetools>
         <name>TreeTools</name>
@@ -694,7 +1230,37 @@
         <size>17636</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_treetools>
-    
+    <addon>viewstate</addon>
+    <addon_viewstate>
+        <name>ViewState</name>
+        <description>ASP/JSF ViewState Decoder and Editor</description>
+        <author>Calum Hutton</author>
+        <version>1</version>
+        <file>viewstate-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/viewstate-alpha-1.zap</url>
+        <hash>SHA1:55decd0f02e3a75bcc8e6f3ce757d569e398a099</hash>
+        <date>2016-09-14</date>
+        <size>25184</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_viewstate>
+    <addon>wappalyzer</addon>
+    <addon_wappalyzer>
+        <name>Technology detection using Wappalyzer</name>
+        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>wappalyzer-alpha-8.zap</file>
+        <status>alpha</status>
+        <changes>Remove the use of passive scan rule.&lt;br&gt;
+    Minor code cleanup.&lt;br&gt;
+    Add support for wappalyzer META tag checks.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/wappalyzer-alpha-8.zap</url>
+        <hash>SHA1:b25bc4338e348fdc31016f440c55f8cffb2c27e3</hash>
+        <date>2017-03-25</date>
+        <size>1275611</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_wappalyzer>
     <addon>webdriverlinux</addon>
     <addon_webdriverlinux>
         <name>Linux WebDrivers</name>
@@ -712,7 +1278,6 @@
         <size>10371607</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_webdriverlinux>
-    
     <addon>webdrivermacos</addon>
     <addon_webdrivermacos>
         <name>MacOS WebDrivers</name>
@@ -730,7 +1295,6 @@
         <size>5870746</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_webdrivermacos>
-    
     <addon>webdriverwindows</addon>
     <addon_webdriverwindows>
         <name>Windows WebDrivers</name>
@@ -748,7 +1312,23 @@
         <size>10202418</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_webdriverwindows>
-
+    <addon>websocket</addon>
+    <addon_websocket>
+        <name>WebSockets</name>
+        <description>Allows you to inspect WebSocket communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>11</version>
+        <file>websocket-release-11.zap</file>
+        <status>release</status>
+        <changes>Unload WebSockets components during uninstallation.&lt;br&gt;
+	Use hostname/port of the handshake message to build the name of the channel.&lt;br&gt;
+	Adjust log levels, from INFO to DEBUG.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/websocket-release-11.zap</url>
+        <hash>SHA1:87e11bdda6b5d313ade2c90f920a6604b17efb95</hash>
+        <date>2016-06-02</date>
+        <size>779268</size>
+        <not-before-version>2.4.3</not-before-version>
+    </addon_websocket>
     <addon>zest</addon>
     <addon_zest>
         <name>Zest - Graphical Security Scripting Language</name>
@@ -775,665 +1355,4 @@
             </addons>
         </dependencies>
     </addon_zest>
-	
-	<addon>accessControl</addon>
-    <addon_accessControl>
-        <name>Access Control Testing</name>
-        <description>Adds a set of tools for testing access control in web applications.</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>accessControl-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Fix an exception when cancelling the "Save" access control report dialogue.&lt;br&gt;
-	Do not allow to dynamically uninstall, not yet supported.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/accessControl-alpha-2.zap</url>
-        <hash>SHA1:967be37f73670af78a04deca1429dec4d8ff9231</hash>
-        <date>2016-06-02</date>
-        <size>495908</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_accessControl>
-    
-    <addon>amf</addon>
-    <addon_amf>
-        <name>AMF</name>
-        <description>Adds support for AMF messages</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>amf-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First release as an add-on, previously bundled with core.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/amf-alpha-1.zap</url>
-        <hash>SHA1:7193f6b263f5a2c2352c2be8963d42944b4ae05f</hash>
-        <date>2016-06-02</date>
-        <size>808609</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_amf>
-    
-    <addon>ascanrulesAlpha</addon>
-    <addon_ascanrulesAlpha>
-        <name>Active scanner rules (alpha)</name>
-        <description>The alpha quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>18</version>
-        <file>ascanrulesAlpha-alpha-18.zap</file>
-        <status>alpha</status>
-        <changes>Added Apache Range Header DoS (CVE-2011-3192) scanner.&lt;br&gt;
-	Fix exception when raising a "Source Code Disclosure - File Inclusion" alert.&lt;br&gt;
-	Adjust log levels of some scanners, from INFO to DEBUG.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/ascanrulesAlpha-alpha-18.zap</url>
-        <hash>SHA1:7e14d4fe67389fa2d230b607b5e5aa7dd8b8c31f</hash>
-        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
-        <date>2016-10-24</date>
-        <size>1333963</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_ascanrulesAlpha>
-    
-    <addon>authstats</addon>
-    <addon_authstats>
-        <name>Authentication Statistics</name>
-        <description>Records logged in/out statistics for all contexts in scope.</description>
-        <author>ZAP Core Team</author>
-        <version>1</version>
-        <file>authstats-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First version&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/authstats-alpha-1.zap</url>
-        <hash>SHA1:c00d7e572faba04ff1262bcc04406599a8b20ffd</hash>
-        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAuthstatsAuthStats</info>
-        <date>2016-08-16</date>
-        <size>11605</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_authstats>
-
-    <addon>browserView</addon>
-    <addon_browserView>
-        <name>Browser View</name>
-        <description>Adds an option to render HTML responses like a browser</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>browserView-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/browserView-alpha-4.zap</url>
-        <hash>SHA1:d48e7768ecac5bb5e12d6e7c36907bfbf95ea46d</hash>
-        <date>2016-06-02</date>
-        <size>180584</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_browserView>
-    
-    <addon>bugtracker</addon>
-    <addon_bugtracker>
-        <name>Bug Tracker</name>
-        <description>Bug Tracker extension.</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>bugtracker-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/bugtracker-alpha-1.zap</url>
-        <hash>SHA1:3c2ae880b9d942fe817483ac515371f5ff2e47c2</hash>
-        <date>2016-08-25</date>
-        <size>1736016</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_bugtracker>
-    
-    <addon>callgraph</addon>
-    <addon_callgraph>
-        <name>Call Graph</name>
-        <description>Allows the user to view a call graph of the selected resources</description>
-        <author>Colm O'Flaherty</author>
-        <version>3</version>
-        <file>callgraph-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/callgraph-alpha-3.zap</url>
-        <hash>SHA1:d72894ec70bd21f30026154c29243d17983b36e9</hash>
-        <date>2016-06-02</date>
-        <size>1157575</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_callgraph>
-    
-    <addon>codedx</addon>
-    <addon_codedx>
-        <name>Code Dx Extension</name>
-        <description>Includes request and response data in XML reports and provides the ability to upload reports directly to a Code Dx server</description>
-        <author>Code Dx, Inc.</author>
-        <version>5</version>
-        <file>codedx-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Add an upload to Code Dx option.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/codedx-alpha-5.zap</url>
-        <hash>SHA1:fad5d14acd070d6ab2b7baae7092a5f75f5b6a8c</hash>
-        <date>2017-04-18</date>
-        <size>1185698</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_codedx>
-    
-    <addon>communityScripts</addon>
-    <addon_communityScripts>
-        <name>Community Scripts</name>
-        <description>Useful ZAP scripts written by the ZAP community.</description>
-        <author>ZAP Community</author>
-        <version>3</version>
-        <file>communityScripts-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Updated with the latest scripts for 2.5.0&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/communityScripts-alpha-3.zap</url>
-        <hash>SHA1:f1c2e0af4cf4500b9d0656723316a6f0e806f668</hash>
-        <info>https://github.com/zaproxy/community-scripts</info>
-        <date>2016-06-02</date>
-        <size>134107</size>
-        <not-before-version>2.4.3</not-before-version>
-    </addon_communityScripts>
-    
-    <addon>cspscanner</addon>
-    <addon_cspscanner>
-        <name>Content Security Policy Scanner</name>
-        <description>Content Security Policy (CSP) Scanner</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>cspscanner-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Fixed missing error and warning messages.&lt;br&gt;
-		Added evidence.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/cspscanner-alpha-4.zap</url>
-        <hash>SHA1:1d672d3575e395c5bd466274979338a5ece2d965</hash>
-        <date>2017-07-27</date>
-        <size>112917</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_cspscanner>
-
-    <addon>customreport</addon>
-    <addon_customreport>
-        <name>CustomReport</name>
-        <description>New HTML report module allows users to customize report content.</description>
-        <author>Chienli Ma</author>
-        <version>2</version>
-        <file>customreport-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/customreport-alpha-2.zap</url>
-        <hash>SHA1:fe8f172a879e5372d040449973ac7a1a133eafd5</hash>
-        <date>2016-06-02</date>
-        <size>557158</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_customreport>
-    
-    <addon>domxss</addon>
-    <addon_domxss>
-        <name>DOM XSS Active scanner rule</name>
-        <description>DOM XSS Active scanner rule</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>domxss-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Skip the scanner if not able to start Firefox.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/domxss-alpha-3.zap</url>
-        <hash>SHA1:b86bdc8d25461bf0922a699d84d635e1bc8dc9a0</hash>
-        <date>2016-10-24</date>
-        <size>192724</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>1.*</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_domxss>
-    
-    <addon>help_bs_BA</addon>
-    <addon_help_bs_BA>
-        <name>Help - Bosnian</name>
-        <description>Bosnian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>5</version>
-        <file>help_bs_BA-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.5.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_bs_BA-alpha-5.zap</url>
-        <hash>SHA1:aa7ed9aa95bff1b2d1aeb547ff6cab7d5a37bef6</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2016-06-02</date>
-        <size>756583</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_help_bs_BA>
-    
-    <addon>help_es_ES</addon>
-    <addon_help_es_ES>
-        <name>Help - Spanish</name>
-        <description>Spanish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>5</version>
-        <file>help_es_ES-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.5.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_es_ES-alpha-5.zap</url>
-        <hash>SHA1:b25a9f3e4db5eb41c19647ec623750043d26325c</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2016-06-02</date>
-        <size>760182</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_help_es_ES>
-    
-    <addon>help_fr_FR</addon>
-    <addon_help_fr_FR>
-        <name>Help - French</name>
-        <description>French version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>5</version>
-        <file>help_fr_FR-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.5.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_fr_FR-alpha-5.zap</url>
-        <hash>SHA1:423675291345b964ca0aeda95550ffd978071f6f</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2016-06-02</date>
-        <size>757459</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_help_fr_FR>
-    
-    <addon>help_ja_JP</addon>
-    <addon_help_ja_JP>
-        <name>Help - Japanese</name>
-        <description>Japanese version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>5</version>
-        <file>help_ja_JP-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.5.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/help_ja_JP-alpha-5.zap</url>
-        <hash>SHA1:33bca35847c84da63a2522fb26c6679cf870211f</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2016-06-02</date>
-        <size>783581</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_help_ja_JP>
-    
-    <addon>highlighter</addon>
-    <addon_highlighter>
-        <name>Highlighter</name>
-        <description>Allows you to highlight strings in the request and response tabs.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>highlighter-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/highlighter-alpha-6.zap</url>
-        <hash>SHA1:ebc48b0880ff7862839ae0158de9ddb038218735</hash>
-        <date>2016-06-02</date>
-        <size>9568</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_highlighter>
-    
-    <addon>httpsInfo</addon>
-    <addon_httpsInfo>
-        <name>HttpsInfo</name>
-        <description>Displays HTTPS status information.</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>httpsInfo-alpha-7.zap</file>
-        <status>alpha</status>
-        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;
-	Issue 758 - General re-working of the extension.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/httpsInfo-alpha-7.zap</url>
-        <hash>SHA1:5fa83cf1adfe80695fbf8209b5cad4b19f2f6787</hash>
-        <date>2016-06-02</date>
-        <size>48860</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_httpsInfo>
-    
-    <addon>importLogFiles</addon>
-    <addon_importLogFiles>
-        <name>Log File Importer</name>
-        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>importLogFiles-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Use API actions when importing files.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importLogFiles-alpha-4.zap</url>
-        <hash>SHA1:ed557f0caf1e7c630532d9171f13f8afaa99be30</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
-        <date>2017-05-05</date>
-        <size>152363</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_importLogFiles>
-
-    <addon>jxbrowser</addon>
-    <addon_jxbrowser>
-        <name>JxBrowser (core)</name>
-        <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jxbrowser-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Added button for selecting URL from Sites tree.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowser-alpha-4.zap</url>
-        <hash>SHA1:b8f0253f88c2e15ef7d2552ac8aac7a0f62d728a</hash>
-        <date>2017-05-05</date>
-        <size>1411594</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_jxbrowser>
-
-    <addon>jxbrowserlinux32</addon>
-    <addon_jxbrowserlinux32>
-        <name>JxBrowser (Linux 32)</name>
-        <description>An embedded browser based on Chromium, Linux 32 specific</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowserlinux32-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux32-alpha-2.zap</url>
-        <hash>SHA1:dbed700fb82554e25e26a73fdac1ad337fb2b5ce</hash>
-        <date>2017-04-25</date>
-        <size>46399267</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverlinux</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserlinux32>
-
-    <addon>jxbrowserlinux64</addon>
-    <addon_jxbrowserlinux64>
-        <name>JxBrowser (Linux 64)</name>
-        <description>An embedded browser based on Chromium, Linux 64 specific</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowserlinux64-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux64-alpha-2.zap</url>
-        <hash>SHA1:49d07afb501d171ce7a04e03876d60951c504349</hash>
-        <date>2017-04-25</date>
-        <size>46037789</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverlinux</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserlinux64>
-
-    <addon>jxbrowsermacos</addon>
-    <addon_jxbrowsermacos>
-        <name>JxBrowser (Mac OS)</name>
-        <description>An embedded browser based on Chromium, Mac OS specific</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowsermacos-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowsermacos-alpha-2.zap</url>
-        <hash>SHA1:9c949adbc339c269dc4880d4b3bf018693914878</hash>
-        <date>2017-04-25</date>
-        <size>51499781</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdrivermacos</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowsermacos>
-
-    <addon>jxbrowserwindows</addon>
-    <addon_jxbrowserwindows>
-        <name>JxBrowser (Windows)</name>
-        <description>An embedded browser based on Chromium, Windows specific</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowserwindows-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.14 which now accepts 'invalid' certificates.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserwindows-alpha-2.zap</url>
-        <hash>SHA1:efb07bab671efb6ed955107a799bf6ade3a4d15f</hash>
-        <date>2017-04-25</date>
-        <size>35906181</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverwindows</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserwindows>
-    
-    <addon>openapi</addon>
-    <addon_openapi>
-        <name>OpenAPI Support</name>
-        <description>Imports and spiders Open API definitions.</description>
-        <author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
-        <version>5</version>
-        <file>openapi-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Run synchronously and return any warnings when importing via API or cmdline.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/openapi-alpha-5.zap</url>
-        <hash>SHA1:10e9d322efce95128647d1760957a94811c0e3a3</hash>
-        <date>2017-05-05</date>
-        <size>2918104</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_openapi>
-
-    <addon>pscanrulesAlpha</addon>
-    <addon_pscanrulesAlpha>
-        <name>Passive scanner rules (alpha)</name>
-        <description>The alpha quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>13</version>
-        <file>pscanrulesAlpha-alpha-13.zap</file>
-        <status>alpha</status>
-        <changes>Issue 3148: Only report HSTS on plain HTTP issue at Low threshold.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/pscanrulesAlpha-alpha-13.zap</url>
-        <hash>SHA1:e62fb2955140ca56ca6b11ad1454b088578e5fe4</hash>
-        <date>2017-01-18</date>
-        <size>1944233</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_pscanrulesAlpha>
-    
-    <addon>replacer</addon>
-    <addon_replacer>
-        <name>Replacer</name>
-        <description>Easy way to replace strings in requests and responses.</description>
-        <author>ZAP Dev Team</author>
-        <version>1</version>
-        <file>replacer-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/replacer-alpha-1.zap</url>
-        <hash>SHA1:f33439b3c89edb394e42728eb4edeed1d5bea9b6</hash>
-        <date>2017-02-01</date>
-        <size>36527</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_replacer>
-
-    <addon>requester</addon>
-    <addon_requester>
-        <name>Requester</name>
-        <description>Request numbered panel.</description>
-        <author>Surikato</author>
-        <version>1</version>
-        <file>requester-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/requester-alpha-1.zap</url>
-        <hash>SHA1:3f43ac40b5b6225ebdc918df0b14cd53f0e7e8a2</hash>
-        <date>2016-06-02</date>
-        <size>40411</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_requester>
-    
-    <addon>revisit</addon>
-    <addon_revisit>
-        <name>Revisit</name>
-        <description>Revisit a site at any time in the past using the session history</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>revisit-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/revisit-alpha-2.zap</url>
-        <hash>SHA1:84087ce758254bc515160b458bcf5c2c82773641</hash>
-        <date>2016-06-02</date>
-        <size>279982</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_revisit>
-    
-    <addon>saml</addon>
-    <addon_saml>
-        <name>SAML Extension</name>
-        <description>Detect, Show, Edit, Fuzz SAML requests</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>saml-alpha-7.zap</file>
-        <status>alpha</status>
-        <changes>Minor code change to work with ZAP 2.5.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/saml-alpha-7.zap</url>
-        <hash>SHA1:47e830cfffbe0742440f9923356ed73f3e817074</hash>
-        <info>https://github.com/zaproxy/zaproxy</info>
-        <date>2017-11-24</date>
-        <size>997657</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_saml>
-    
-    <addon>sequence</addon>
-    <addon_sequence>
-        <name>Sequence</name>
-        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>sequence-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Allow to dynamically unload the add-on.&lt;br&gt;
-	Other code changes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sequence-alpha-3.zap</url>
-        <hash>SHA1:73f8e7a72f29b5c9ae26e076ddfb8cfeec64a6c9</hash>
-        <date>2016-06-02</date>
-        <size>37514</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_sequence>
-    
-    <addon>sniTerminator</addon>
-    <addon_sniTerminator>
-        <name>SNI Terminator</name>
-        <description>Transparent HTTP proxying</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>sniTerminator-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Update library to work with newer versions of ZAP.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sniTerminator-alpha-4.zap</url>
-        <hash>SHA1:aa38bb7f929d6d7b54ba4445a9a6c1c276951472</hash>
-        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
-        <date>2016-06-02</date>
-        <size>247164</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_sniTerminator>
-    
-    <addon>soap</addon>
-    <addon_soap>
-        <name>SOAP Scanner</name>
-        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
-        <author>Alberto (albertov91) + ZAP Core team</author>
-        <version>3</version>
-        <file>soap-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Added API, help and other minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/soap-alpha-3.zap</url>
-        <hash>SHA1:c02815ca249e8d2736d9e66498bfe7d43ed0d464</hash>
-        <date>2017-03-31</date>
-        <size>7337575</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_soap>
-    
-    <addon>sse</addon>
-    <addon_sse>
-        <name>Server-Sent Events</name>
-        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>sse-alpha-9.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sse-alpha-9.zap</url>
-        <hash>SHA1:c642ed5fa03bc2c7840c722baf9dc9d842197e9d</hash>
-        <date>2016-06-02</date>
-        <size>331696</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_sse>
-
-    <addon>tlsdebug</addon>
-    <addon_tlsdebug>
-        <name>TLS Debug</name>
-        <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
-        <author>P.M.J. Roth</author>
-        <version>1</version>
-        <file>tlsdebug-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/tlsdebug-alpha-1.zap</url>
-        <hash>SHA1:0b987f507e0219817ba012c38df890c862ce0ea5</hash>
-        <date>2016-11-02</date>
-        <size>22114</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_tlsdebug>
-    
-    <addon>viewstate</addon>
-    <addon_viewstate>
-        <name>ViewState</name>
-        <description>ASP/JSF ViewState Decoder and Editor</description>
-        <author>Calum Hutton</author>
-        <version>1</version>
-        <file>viewstate-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/viewstate-alpha-1.zap</url>
-        <hash>SHA1:55decd0f02e3a75bcc8e6f3ce757d569e398a099</hash>
-        <date>2016-09-14</date>
-        <size>25184</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_viewstate>
-    
-    <addon>wappalyzer</addon>
-    <addon_wappalyzer>
-        <name>Technology detection using Wappalyzer</name>
-        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>wappalyzer-alpha-8.zap</file>
-        <status>alpha</status>
-        <changes>Remove the use of passive scan rule.&lt;br&gt;
-    Minor code cleanup.&lt;br&gt;
-    Add support for wappalyzer META tag checks.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/wappalyzer-alpha-8.zap</url>
-        <hash>SHA1:b25bc4338e348fdc31016f440c55f8cffb2c27e3</hash>
-        <date>2017-03-25</date>
-        <size>1275611</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_wappalyzer>
-	
 </ZAP>

--- a/ZapVersions-2.6.xml
+++ b/ZapVersions-2.6.xml
@@ -1,37 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
-	
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
+    <addon>accessControl</addon>
+    <addon_accessControl>
+        <name>Access Control Testing</name>
+        <description>Adds a set of tools for testing access control in web applications.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>accessControl-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Fix exception that occurred with Java 9 (Issue 3934).&lt;br&gt;
+	Allow to copy multiple results and copy correct value from the result column.&lt;br&gt;
+	Display correct message when the table is sorted.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/accessControl-alpha-3.zap</url>
+        <hash>SHA1:21f36dc3c4b6ebff10ac8fbb4f358b78b89328d0</hash>
+        <date>2017-11-24</date>
+        <size>512096</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_accessControl>
+    <addon>alertFilters</addon>
+    <addon_alertFilters>
+        <name>Context Alert Filters</name>
+        <description>Allows you to automate the changing of alert risk levels.</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>alertFilters-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Dynamically unload the add-on.&lt;br&gt;
+	Clear filters on session changes (Issue 3683).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/alertFilters-beta-5.zap</url>
+        <hash>SHA1:30ca048b72f3c6de3c011ab00bdb7c8822dedda0</hash>
+        <date>2017-11-24</date>
+        <size>285973</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_alertFilters>
+    <addon>alertReport</addon>
+    <addon_alertReport>
+        <name>Report alert generator</name>
+        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
+        <author>Talsoft SRL</author>
+        <version>14</version>
+        <file>alertReport-beta-14.zap</file>
+        <status>beta</status>
+        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
+	Include Alert's evidence in report of ODT format.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertReport-beta-14.zap</url>
+        <hash>SHA1:d5f2a410eafec455e4b1051eb68d7d6560c68be5</hash>
+        <info>http://www.talsoft.com.ar</info>
+        <date>2016-06-02</date>
+        <size>9712171</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_alertReport>
+    <addon>amf</addon>
+    <addon_amf>
+        <name>AMF</name>
+        <description>Adds support for AMF messages</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>amf-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Deserialise the AMF request.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/amf-alpha-2.zap</url>
+        <hash>SHA1:e34f73753902f2ebedc0be130b446cae39ff4784</hash>
+        <date>2017-05-26</date>
+        <size>813478</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_amf>
     <addon>ascanrules</addon>
     <addon_ascanrules>
         <name>Active scanner rules</name>
@@ -51,7 +114,170 @@
         <size>594932</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_ascanrules>
-    
+    <addon>ascanrulesAlpha</addon>
+    <addon_ascanrulesAlpha>
+        <name>Active scanner rules (alpha)</name>
+        <description>The alpha quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>20</version>
+        <file>ascanrulesAlpha-alpha-20.zap</file>
+        <status>alpha</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Correct handling of messages with emtpy path.&lt;br&gt;
+	Add Get for Post Scanner.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/ascanrulesAlpha-alpha-20.zap</url>
+        <hash>SHA1:df085930d5a817a60a1dd98cb3beae5750916186</hash>
+        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
+        <date>2017-11-24</date>
+        <size>1434903</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_ascanrulesAlpha>
+    <addon>ascanrulesBeta</addon>
+    <addon_ascanrulesBeta>
+        <name>Active scanner rules (beta)</name>
+        <description>The beta quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>22</version>
+        <file>ascanrulesBeta-beta-22.zap</file>
+        <status>beta</status>
+        <changes>Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).&lt;br&gt;
+	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).&lt;br&gt;
+	Support security annotations for forms that dont need anti-CSRF tokens.&lt;br&gt;
+	Changed XXE rule to use new callback extension.&lt;br&gt;
+	Notify of messages sent during Heartbleed scanning (Issue 2425).&lt;br&gt;
+	Fix false positive in Code Disclosure - CVE-2012-1823 on image content (Issue 3846).&lt;br&gt;
+	Fix false positive in Backup File Disclosure scanner on 403 responses (Issue 3911).&lt;br&gt;
+	CsrfTokenScan : Keep session cookies instead of deleting all of them&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/ascanrulesBeta-beta-22.zap</url>
+        <hash>SHA1:6c764624a8c3ddbdc47d0b5276244f3681a5c060</hash>
+        <date>2017-11-24</date>
+        <size>2762546</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_ascanrulesBeta>
+    <addon>authstats</addon>
+    <addon_authstats>
+        <name>Authentication Statistics</name>
+        <description>Records logged in/out statistics for all contexts in scope.</description>
+        <author>ZAP Core Team</author>
+        <version>1</version>
+        <file>authstats-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>First version&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/authstats-alpha-1.zap</url>
+        <hash>SHA1:c00d7e572faba04ff1262bcc04406599a8b20ffd</hash>
+        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAuthstatsAuthStats</info>
+        <date>2016-08-16</date>
+        <size>11605</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_authstats>
+    <addon>beanshell</addon>
+    <addon_beanshell>
+        <name>BeanShell Console</name>
+        <description>Provides a BeanShell Console</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>beanshell-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/beanshell-beta-5.zap</url>
+        <hash>SHA1:1fc34a12180cd700cc6fad2236641936cece8cdc</hash>
+        <date>2016-06-02</date>
+        <size>562333</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_beanshell>
+    <addon>browserView</addon>
+    <addon_browserView>
+        <name>Browser View</name>
+        <description>Adds an option to render HTML responses like a browser</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>browserView-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Allow to properly scroll the rendered page.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/browserView-alpha-5.zap</url>
+        <hash>SHA1:6acfc72f0491d3b391d6633b3dc89ad6d4d4c801</hash>
+        <date>2017-07-21</date>
+        <size>188142</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_browserView>
+    <addon>bruteforce</addon>
+    <addon_bruteforce>
+        <name>Forced Browse</name>
+        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>bruteforce-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Allow to set higher number of threads (Issue 2912).&lt;br&gt;
+    Fix issue with multiple concurrent scans.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/bruteforce-beta-6.zap</url>
+        <hash>SHA1:5acad406b5d9abe8cf88b8c67eb9b7b9a4c8a5b0</hash>
+        <date>2017-04-03</date>
+        <size>1000348</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_bruteforce>
+    <addon>bugtracker</addon>
+    <addon_bugtracker>
+        <name>Bug Tracker</name>
+        <description>Bug Tracker extension.</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>bugtracker-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Added help for the add-on</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/bugtracker-alpha-2.zap</url>
+        <hash>SHA1:156b7ad6616db6a17d96ecea42c44542e5bbf163</hash>
+        <date>2017-05-26</date>
+        <size>1995812</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_bugtracker>
+    <addon>callgraph</addon>
+    <addon_callgraph>
+        <name>Call Graph</name>
+        <description>Allows the user to view a call graph of the selected resources</description>
+        <author>Colm O'Flaherty</author>
+        <version>4</version>
+        <file>callgraph-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Finish internationalisation.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/callgraph-alpha-4.zap</url>
+        <hash>SHA1:c369e9bc5c18800debe566595cdc73cc7a7f4629</hash>
+        <date>2017-11-24</date>
+        <size>1158457</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_callgraph>
+    <addon>codedx</addon>
+    <addon_codedx>
+        <name>Code Dx Extension</name>
+        <description>Includes request and response data in XML reports and provides the ability to upload reports directly to a Code Dx server</description>
+        <author>Code Dx, Inc.</author>
+        <version>5</version>
+        <file>codedx-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Add an upload to Code Dx option.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/codedx-alpha-5.zap</url>
+        <hash>SHA1:fad5d14acd070d6ab2b7baae7092a5f75f5b6a8c</hash>
+        <date>2017-04-18</date>
+        <size>1185698</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_codedx>
+    <addon>communityScripts</addon>
+    <addon_communityScripts>
+        <name>Community Scripts</name>
+        <description>Useful ZAP scripts written by the ZAP community.</description>
+        <author>ZAP Community</author>
+        <version>4</version>
+        <file>communityScripts-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated with the latest scripts for 2.6.0&lt;br&gt;
+	Stop the scripts from being registered twice&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/communityScripts-alpha-4.zap</url>
+        <hash>SHA1:822bb272b10cf3f185e92f297dec1ffe3ca142bb</hash>
+        <info>https://github.com/zaproxy/community-scripts</info>
+        <date>2017-10-17</date>
+        <size>335736</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_communityScripts>
     <addon>coreLang</addon>
     <addon_coreLang>
         <name>Core Language Files</name>
@@ -68,7 +294,55 @@
         <size>2715653</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_coreLang>
-    
+    <addon>cspscanner</addon>
+    <addon_cspscanner>
+        <name>Content Security Policy Scanner</name>
+        <description>Content Security Policy (CSP) Scanner</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>cspscanner-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Fixed missing error and warning messages.&lt;br&gt;
+		Added evidence.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/cspscanner-alpha-4.zap</url>
+        <hash>SHA1:1d672d3575e395c5bd466274979338a5ece2d965</hash>
+        <date>2017-07-27</date>
+        <size>112917</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_cspscanner>
+    <addon>customreport</addon>
+    <addon_customreport>
+        <name>CustomReport</name>
+        <description>New HTML report module allows users to customize report content.</description>
+        <author>Chienli Ma</author>
+        <version>2</version>
+        <file>customreport-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/customreport-alpha-2.zap</url>
+        <hash>SHA1:fe8f172a879e5372d040449973ac7a1a133eafd5</hash>
+        <date>2016-06-02</date>
+        <size>557158</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_customreport>
+    <addon>diff</addon>
+    <addon_diff>
+        <name>Diff</name>
+        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>diff-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/diff-beta-7.zap</url>
+        <hash>SHA1:1a7cb9e64e0740d752280729dda4c3f606c29a6c</hash>
+        <date>2017-04-03</date>
+        <size>235040</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_diff>
     <addon>directorylistv1</addon>
     <addon_directorylistv1>
         <name>Directory List v1.0</name>
@@ -86,7 +360,6 @@
         <size>847617</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv1>
-    
     <addon>directorylistv2_3</addon>
     <addon_directorylistv2_3>
         <name>Directory List v2.3</name>
@@ -104,7 +377,6 @@
         <size>8608732</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3>
-    
     <addon>directorylistv2_3_lc</addon>
     <addon_directorylistv2_3_lc>
         <name>Directory List v2.3 LC</name>
@@ -121,7 +393,31 @@
         <size>7454765</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_directorylistv2_3_lc>
-
+    <addon>domxss</addon>
+    <addon_domxss>
+        <name>DOM XSS Active scanner rule</name>
+        <description>DOM XSS Active scanner rule</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>domxss-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Allow to use newer versions of Firefox (Issue 3396).&lt;br&gt;
+	Provide the reason why the scanner was skipped.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/domxss-alpha-4.zap</url>
+        <hash>SHA1:031676c8d795251f94c8c57c645f2de236b69551</hash>
+        <date>2017-08-18</date>
+        <size>193882</size>
+        <not-before-version>2.6.0</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>2.*</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_domxss>
     <addon>exportreport</addon>
     <addon_exportreport>
         <name>Export Report</name>
@@ -137,7 +433,6 @@
         <size>6201200</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_exportreport>
-
     <addon>formhandler</addon>
     <addon_formhandler>
         <name>Form Handler</name>
@@ -153,7 +448,29 @@
         <size>87717</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_formhandler>
-    
+    <addon>fuzz</addon>
+    <addon_fuzz>
+        <name>AdvFuzzer</name>
+        <description>Advanced fuzzer for manual testing</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <semver>2.0.1</semver>
+        <file>fuzz-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+    Ignore empty payloads when highlighting or detecting reflections.&lt;br&gt;
+    Contains new number generator payload.&lt;br&gt;
+    Add null/empty payload generator.&lt;br&gt;
+    Issue 3557: Backport export changes.&lt;br&gt;    
+    Set fuzzer script types enabled by default (Issue 2997).&lt;br&gt;
+    Add description to script types.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/fuzz-beta-9.zap</url>
+        <hash>SHA1:56c15b8da1e19909ecc7fe06f29c6ba6b1c7f291</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
+        <date>2017-11-24</date>
+        <size>2400821</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_fuzz>
     <addon>fuzzdb</addon>
     <addon_fuzzdb>
         <name>FuzzDB files</name>
@@ -170,7 +487,6 @@
         <size>5626766</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_fuzzdb>
-    
     <addon>gettingStarted</addon>
     <addon_gettingStarted>
         <name>Getting Started with ZAP Guide</name>
@@ -186,7 +502,6 @@
         <size>578773</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_gettingStarted>
-    
     <addon>help</addon>
     <addon_help>
         <name>Help - English</name>
@@ -203,7 +518,70 @@
         <size>763371</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_help>
-
+    <addon>help_bs_BA</addon>
+    <addon_help_bs_BA>
+        <name>Help - Bosnian</name>
+        <description>Bosnian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>6</version>
+        <file>help_bs_BA-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.6.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_bs_BA-alpha-6.zap</url>
+        <hash>SHA1:8f54f0fe065762f101ee1818545dacca581b2a2c</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2017-11-24</date>
+        <size>773399</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_help_bs_BA>
+    <addon>help_es_ES</addon>
+    <addon_help_es_ES>
+        <name>Help - Spanish</name>
+        <description>Spanish version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>6</version>
+        <file>help_es_ES-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.6.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_es_ES-alpha-6.zap</url>
+        <hash>SHA1:5055f43457c118363b828a6e83a036e4b5b13d52</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2017-11-24</date>
+        <size>775922</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_help_es_ES>
+    <addon>help_fr_FR</addon>
+    <addon_help_fr_FR>
+        <name>Help - French</name>
+        <description>French version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>6</version>
+        <file>help_fr_FR-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.6.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_fr_FR-alpha-6.zap</url>
+        <hash>SHA1:d2946f64199d1b4dad767f86ae92b408fa61c66f</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2017-11-24</date>
+        <size>773836</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_help_fr_FR>
+    <addon>help_ja_JP</addon>
+    <addon_help_ja_JP>
+        <name>Help - Japanese</name>
+        <description>Japanese version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>6</version>
+        <file>help_ja_JP-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for 2.6.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_ja_JP-alpha-6.zap</url>
+        <hash>SHA1:50cf8563f1bd97f9cc3c9e90132057b5a6f8d484</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2017-11-24</date>
+        <size>799759</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_help_ja_JP>
     <addon>help_pt_BR</addon>
     <addon_help_pt_BR>
         <name>Help - Portuguese, Brazilian</name>
@@ -220,7 +598,234 @@
         <size>817771</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_help_pt_BR>
-    
+    <addon>highlighter</addon>
+    <addon_highlighter>
+        <name>Highlighter</name>
+        <description>Allows you to highlight strings in the request and response tabs.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>highlighter-alpha-6.zap</file>
+        <status>alpha</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/highlighter-alpha-6.zap</url>
+        <hash>SHA1:ebc48b0880ff7862839ae0158de9ddb038218735</hash>
+        <date>2016-06-02</date>
+        <size>9568</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_highlighter>
+    <addon>httpsInfo</addon>
+    <addon_httpsInfo>
+        <name>HttpsInfo</name>
+        <description>Displays HTTPS configuration information.</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>httpsInfo-alpha-10.zap</file>
+        <status>alpha</status>
+        <changes>Upgrade to use DeepViolet 5.0.3, which provides some minor logging changes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/httpsInfo-alpha-10.zap</url>
+        <hash>SHA1:1f862f891f7a6aebf474c654547b98ffcb8651bf</hash>
+        <date>2017-11-24</date>
+        <size>5545558</size>
+        <not-before-version>2.4.0</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_httpsInfo>
+    <addon>importLogFiles</addon>
+    <addon_importLogFiles>
+        <name>Log File Importer</name>
+        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>importLogFiles-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Use API actions when importing files.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importLogFiles-alpha-4.zap</url>
+        <hash>SHA1:ed557f0caf1e7c630532d9171f13f8afaa99be30</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
+        <date>2017-05-05</date>
+        <size>152363</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_importLogFiles>
+    <addon>importurls</addon>
+    <addon_importurls>
+        <name>Import files containing URLs</name>
+        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>importurls-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Minor change to help content.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importurls-beta-4.zap</url>
+        <hash>SHA1:e3df25f154a3a2001a8afffabebae9bf0a066416</hash>
+        <date>2017-11-24</date>
+        <size>223832</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_importurls>
+    <addon>invoke</addon>
+    <addon_invoke>
+        <name>Invoke Applications</name>
+        <description>Invoke external applications passing context related information such as URLs and parameters</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>invoke-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Report/log when the application fails to start (related to Issue 3960).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/invoke-beta-7.zap</url>
+        <hash>SHA1:311a21e7ae14d996422bf48813c3b10602a98e00</hash>
+        <date>2017-10-19</date>
+        <size>291274</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_invoke>
+    <addon>jruby</addon>
+    <addon_jruby>
+        <name>Ruby scripting</name>
+        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>jruby-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Add template for HTTP Sender script.&lt;br&gt;
+    Dynamically unload the add-on.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jruby-beta-5.zap</url>
+        <hash>SHA1:30920fbda214b6dea5dbf77a0f8c397cb38f2782</hash>
+        <date>2017-09-28</date>
+        <size>22471619</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jruby>
+    <addon>jxbrowser</addon>
+    <addon_jxbrowser>
+        <name>JxBrowser (core)</name>
+        <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>jxbrowser-alpha-7.zap</file>
+        <status>alpha</status>
+        <changes>Updated to JxBrowser 6.17.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowser-alpha-7.zap</url>
+        <hash>SHA1:661745f3809e80bc72251a5eebc21c98441f0eec</hash>
+        <date>2017-11-20</date>
+        <size>1412665</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_jxbrowser>
+    <addon>jxbrowserlinux32</addon>
+    <addon_jxbrowserlinux32>
+        <name>JxBrowser (Linux 32)</name>
+        <description>An embedded browser based on Chromium, Linux 32 specific</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>jxbrowserlinux32-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.14.2.&lt;br&gt;
+		Updated to support latest selenium interfaces.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux32-alpha-3.zap</url>
+        <hash>SHA1:ac8303a826fafe4df75ef348b5d2f7ce1f134cb6</hash>
+        <date>2017-08-18</date>
+        <size>47149067</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverlinux</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserlinux32>
+    <addon>jxbrowserlinux64</addon>
+    <addon_jxbrowserlinux64>
+        <name>JxBrowser (Linux 64)</name>
+        <description>An embedded browser based on Chromium, Linux 64 specific</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jxbrowserlinux64-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux64-alpha-4.zap</url>
+        <hash>SHA1:db770aa5b37d386c142ba1943a6b2928dbf6cd23</hash>
+        <date>2017-11-20</date>
+        <size>52750394</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverlinux</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserlinux64>
+    <addon>jxbrowsermacos</addon>
+    <addon_jxbrowsermacos>
+        <name>JxBrowser (Mac OS)</name>
+        <description>An embedded browser based on Chromium, Mac OS specific</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jxbrowsermacos-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowsermacos-alpha-4.zap</url>
+        <hash>SHA1:a57a6d297feda6e842b5756685f19bbf3b31ca95</hash>
+        <date>2017-11-20</date>
+        <size>56486892</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdrivermacos</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowsermacos>
+    <addon>jxbrowserwindows</addon>
+    <addon_jxbrowserwindows>
+        <name>JxBrowser (Windows)</name>
+        <description>An embedded browser based on Chromium, Windows specific</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>jxbrowserwindows-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserwindows-alpha-4.zap</url>
+        <hash>SHA1:3cdbaa964a2fea7b6c9d7fc696253d6a90eb46b1</hash>
+        <date>2017-11-20</date>
+        <size>36680513</size>
+        <not-before-version>2.5.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>jxbrowser</id>
+                </addon>
+                <addon>
+                    <id>webdriverwindows</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_jxbrowserwindows>
+    <addon>jython</addon>
+    <addon_jython>
+        <name>Python scripting</name>
+        <description>Allows Python to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>jython-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Do not initialise java.awt.Toolkit when in daemon.&lt;br&gt;
+	Update HTTP Sender template with initiator ID of AJAX Spider.&lt;br&gt;
+	Added extender template and example.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jython-beta-7.zap</url>
+        <hash>SHA1:00e03758368f562d26ba135155a39f1976b003cc</hash>
+        <date>2017-10-27</date>
+        <size>41727201</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_jython>
     <addon>onlineMenu</addon>
     <addon_onlineMenu>
         <name>Online menus</name>
@@ -237,7 +842,55 @@
         <size>200046</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_onlineMenu>
-    
+    <addon>openapi</addon>
+    <addon_openapi>
+        <name>OpenAPI Support</name>
+        <description>Imports and spiders Open API definitions.</description>
+        <author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
+        <version>8</version>
+        <file>openapi-alpha-8.zap</file>
+        <status>alpha</status>
+        <changes>Fix NPE in BodyGenerator.&lt;br&gt;
+		Fix NPEs when a parameter is null.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/openapi-alpha-8.zap</url>
+        <hash>SHA1:c28949de9794a974ff54864a54970d9a4ae0612e</hash>
+        <date>2017-11-24</date>
+        <size>3171797</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_openapi>
+    <addon>plugnhack</addon>
+    <addon_plugnhack>
+        <name>Plug-n-Hack Configuration</name>
+        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>plugnhack-beta-10.zap</file>
+        <status>beta</status>
+        <changes>Make breakpoint dialogues modal.&lt;br&gt;
+    Changed to use api nonces and include new fx_pnh.xpi (still unsigned).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/plugnhack-beta-10.zap</url>
+        <hash>SHA1:a71447529ca963139d454e940eff2a8ef4625dde</hash>
+        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
+        <date>2017-06-20</date>
+        <size>692662</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_plugnhack>
+    <addon>portscan</addon>
+    <addon_portscan>
+        <name>Port Scanner</name>
+        <description>Allows to port scan a target server</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>portscan-beta-8.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/portscan-beta-8.zap</url>
+        <hash>SHA1:8c3c025534e804eede8d26fb3d5febec51059d96</hash>
+        <date>2017-11-24</date>
+        <size>633257</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_portscan>
     <addon>pscanrules</addon>
     <addon_pscanrules>
         <name>Passive scanner rules</name>
@@ -257,7 +910,41 @@
         <size>521226</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_pscanrules>
-    
+    <addon>pscanrulesAlpha</addon>
+    <addon_pscanrulesAlpha>
+        <name>Passive scanner rules (alpha)</name>
+        <description>The alpha quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>18</version>
+        <file>pscanrulesAlpha-alpha-18.zap</file>
+        <status>alpha</status>
+        <changes>Correct typo in XCOLD alert description (Issue 3997).&lt;br&gt;
+	Do not set a value in the attack fields.&lt;br&gt;
+	Do not rely on system's charset to create request/response bodies.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/pscanrulesAlpha-alpha-18.zap</url>
+        <hash>SHA1:c8ec9c62c2d94e52d36b14cd586eb5d5c0b31e20</hash>
+        <date>2017-11-24</date>
+        <size>2214618</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_pscanrulesAlpha>
+    <addon>pscanrulesBeta</addon>
+    <addon_pscanrulesBeta>
+        <name>Passive scanner rules (beta)</name>
+        <description>The beta quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>17</version>
+        <file>pscanrulesBeta-beta-17.zap</file>
+        <status>beta</status>
+        <changes>Minor changes to InsecureJFSViewStatePassiveScanner (check response contains JSF viewstate or if it's server stored).&lt;br/&gt;
+	Improve the domain matching in CookieLooselyScopedScanner.&lt;br/&gt;
+	Issue 3449: CSRFcountermeasures passive scanner now raises alerts on a per-form basis on pages with multiple forms.&lt;br/&gt; 
+	Issue 3937: Update ServletParameterPollutionScanner reference.&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/pscanrulesBeta-beta-17.zap</url>
+        <hash>SHA1:7d1870ff53c1b9ea361d8033ca203c9cec9d5e93</hash>
+        <date>2017-11-24</date>
+        <size>557020</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_pscanrulesBeta>
     <addon>quickstart</addon>
     <addon_quickstart>
         <name>Quick Start</name>
@@ -274,7 +961,35 @@
         <size>370682</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_quickstart>
-    
+    <addon>replacer</addon>
+    <addon_replacer>
+        <name>Replacer</name>
+        <description>Easy way to replace strings in requests and responses.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>replacer-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Added API support</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/replacer-beta-3.zap</url>
+        <hash>SHA1:9bfa4d030c8ab519f05250dc57af1e194a8563a0</hash>
+        <date>2017-06-23</date>
+        <size>283688</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_replacer>
+    <addon>requester</addon>
+    <addon_requester>
+        <name>Requester</name>
+        <description>Request numbered panel.</description>
+        <author>Surikato</author>
+        <version>1</version>
+        <file>requester-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/requester-alpha-1.zap</url>
+        <hash>SHA1:3f43ac40b5b6225ebdc918df0b14cd53f0e7e8a2</hash>
+        <date>2016-06-02</date>
+        <size>40411</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_requester>
     <addon>reveal</addon>
     <addon_reveal>
         <name>Reveal</name>
@@ -290,7 +1005,37 @@
         <size>221496</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_reveal>
-    
+    <addon>revisit</addon>
+    <addon_revisit>
+        <name>Revisit</name>
+        <description>Revisit a site at any time in the past using the session history</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>revisit-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/revisit-alpha-2.zap</url>
+        <hash>SHA1:84087ce758254bc515160b458bcf5c2c82773641</hash>
+        <date>2016-06-02</date>
+        <size>279982</size>
+        <not-before-version>2.4.2</not-before-version>
+    </addon_revisit>
+    <addon>saml</addon>
+    <addon_saml>
+        <name>SAML Extension</name>
+        <description>Detect, Show, Edit, Fuzz SAML requests</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>saml-alpha-7.zap</file>
+        <status>alpha</status>
+        <changes>Minor code change to work with ZAP 2.5.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/saml-alpha-7.zap</url>
+        <hash>SHA1:47e830cfffbe0742440f9923356ed73f3e817074</hash>
+        <info>https://github.com/zaproxy/zaproxy</info>
+        <date>2017-11-24</date>
+        <size>997657</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_saml>
     <addon>saverawmessage</addon>
     <addon_saverawmessage>
         <name>Save Raw Message</name>
@@ -306,7 +1051,25 @@
         <size>27005</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_saverawmessage>
-    
+    <addon>scripts</addon>
+    <addon_scripts>
+        <name>Script Console</name>
+        <description>Supports all JSR 223 scripting languages</description>
+        <author>ZAP Dev Team</author>
+        <version>21</version>
+        <file>scripts-beta-21.zap</file>
+        <status>beta</status>
+        <changes>Show script types in alphabetical order in dialogues New and Load Script.&lt;br&gt;
+	Fix an exception when installing extender scripts with errors.&lt;br&gt;
+	Correct state of Enabled checkbox when creating a script from templates.&lt;br&gt;
+	Allow to enable code folding in script text area.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/scripts-beta-21.zap</url>
+        <hash>SHA1:d98f881c4fc631d51c970b3d8f1bc3b2f212ab45</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
+        <date>2017-11-24</date>
+        <size>572335</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_scripts>
     <addon>selenium</addon>
     <addon_selenium>
         <name>Selenium</name>
@@ -326,7 +1089,64 @@
             <javaversion>1.8</javaversion>
         </dependencies>
     </addon_selenium>
-
+    <addon>sequence</addon>
+    <addon_sequence>
+        <name>Sequence</name>
+        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>sequence-alpha-4.zap</file>
+        <status>alpha</status>
+        <changes>Correct error message to include the script name.&lt;br&gt;
+    Add help content (Issue 2191).&lt;br&gt;
+    Depend on Zest extension, since it is currently the only script option for Sequence scripts.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/sequence-alpha-4.zap</url>
+        <hash>SHA1:734c30eddc68fa938e9f7eedb8d3284c255b5038</hash>
+        <date>2017-05-25</date>
+        <size>1319013</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>zest</id>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_sequence>
+    <addon>sniTerminator</addon>
+    <addon_sniTerminator>
+        <name>SNI Terminator</name>
+        <description>Transparent HTTP proxying</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>sniTerminator-alpha-5.zap</file>
+        <status>alpha</status>
+        <changes>Minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/sniTerminator-alpha-5.zap</url>
+        <hash>SHA1:e84387ae6343989c2d1d943797c22c5f1bf990c2</hash>
+        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
+        <date>2017-11-24</date>
+        <size>254816</size>
+        <not-before-version>2.4.1</not-before-version>
+        <dependencies>
+            <javaversion>1.8</javaversion>
+        </dependencies>
+    </addon_sniTerminator>
+    <addon>soap</addon>
+    <addon_soap>
+        <name>SOAP Scanner</name>
+        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
+        <author>Alberto (albertov91) + ZAP Core team</author>
+        <version>3</version>
+        <file>soap-alpha-3.zap</file>
+        <status>alpha</status>
+        <changes>Added API, help and other minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/soap-alpha-3.zap</url>
+        <hash>SHA1:c02815ca249e8d2736d9e66498bfe7d43ed0d464</hash>
+        <date>2017-03-31</date>
+        <size>7337575</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_soap>
     <addon>spiderAjax</addon>
     <addon_spiderAjax>
         <name>Ajax Spider</name>
@@ -353,7 +1173,198 @@
             </addons>
         </dependencies>
     </addon_spiderAjax>
-    
+    <addon>sqliplugin</addon>
+    <addon_sqliplugin>
+        <name>Advanced SQLInjection Scanner</name>
+        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
+        <author>Andrea Pompili (Yhawke)</author>
+        <version>11</version>
+        <file>sqliplugin-beta-11.zap</file>
+        <status>beta</status>
+        <changes>Check all DB techs when evaluating if the scanner should be run.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sqliplugin-beta-11.zap</url>
+        <hash>SHA1:33b91ef51c3fb322efe14a8da56a77252760d392</hash>
+        <date>2016-07-07</date>
+        <size>104490</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_sqliplugin>
+    <addon>sse</addon>
+    <addon_sse>
+        <name>Server-Sent Events</name>
+        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>sse-alpha-9.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sse-alpha-9.zap</url>
+        <hash>SHA1:c642ed5fa03bc2c7840c722baf9dc9d842197e9d</hash>
+        <date>2016-06-02</date>
+        <size>331696</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_sse>
+    <addon>svndigger</addon>
+    <addon_svndigger>
+        <name>SVN Digger files</name>
+        <description>SVN Digger files which can be used with ZAP forced browsing</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>svndigger-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/svndigger-beta-3.zap</url>
+        <hash>SHA1:257803a38ab33b7645deb63562d1fcce2c4fb46c</hash>
+        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
+        <date>2016-06-02</date>
+        <size>614846</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_svndigger>
+    <addon>tips</addon>
+    <addon_tips>
+        <name>Tips and Tricks</name>
+        <description>Display ZAP Tips and Tricks</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>tips-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tips-beta-6.zap</url>
+        <hash>SHA1:ae835ec3e884148f1ff49daf6fc80d613e28e297</hash>
+        <date>2017-04-03</date>
+        <size>501880</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_tips>
+    <addon>tlsdebug</addon>
+    <addon_tlsdebug>
+        <name>TLS Debug</name>
+        <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
+        <author>P.M.J. Roth</author>
+        <version>2</version>
+        <file>tlsdebug-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tlsdebug-alpha-2.zap</url>
+        <hash>SHA1:813cedda7bf5afe7c0b12ca0b520a11fc0829805</hash>
+        <date>2017-11-24</date>
+        <size>234477</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_tlsdebug>
+    <addon>tokengen</addon>
+    <addon_tokengen>
+        <name>Token generation and analysis</name>
+        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
+        <author>ZAP Dev Team</author>
+        <version>11</version>
+        <file>tokengen-beta-11.zap</file>
+        <status>beta</status>
+        <changes>Use custom HTTP Sender initiator ID.&lt;br&gt;
+	Show same cookies once in Generate Tokens dialogue (Issue 2116).&lt;br&gt;
+	Fix exception when no tokens are found (Issue 2116).&lt;br&gt;
+	Added help file.&lt;br&gt;
+	Issue 2338: Allow dynamic timeout adjustment to combat read timeout issues.&lt;br&gt;
+	Ensure initial dialog is properly sized.&lt;br&gt;
+	Issue 2000: Title caps adjustments.&lt;br&gt;
+	Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Ensure Analyse Token dialogue is shown in front of main window.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tokengen-beta-11.zap</url>
+        <hash>SHA1:39b89cb4404a59b8df848e6f69cb74146d80c84e</hash>
+        <date>2017-11-24</date>
+        <size>478974</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_tokengen>
+    <addon>treetools</addon>
+    <addon_treetools>
+        <name>TreeTools</name>
+        <description>Tools to add functionality to the tree view.</description>
+        <author>Carl Sampson</author>
+        <version>6</version>
+        <file>treetools-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Safe menu items will now be enabled in protected and safe modes (Issue 1278).</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/treetools-beta-6.zap</url>
+        <hash>SHA1:65dc679630d1d273cb4e8f541247d1deeff836e6</hash>
+        <date>2016-06-02</date>
+        <size>17636</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_treetools>
+    <addon>viewstate</addon>
+    <addon_viewstate>
+        <name>ViewState</name>
+        <description>ASP/JSF ViewState Decoder and Editor</description>
+        <author>Calum Hutton</author>
+        <version>1</version>
+        <file>viewstate-alpha-1.zap</file>
+        <status>alpha</status>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/viewstate-alpha-1.zap</url>
+        <hash>SHA1:55decd0f02e3a75bcc8e6f3ce757d569e398a099</hash>
+        <date>2016-09-14</date>
+        <size>25184</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_viewstate>
+    <addon>wappalyzer</addon>
+    <addon_wappalyzer>
+        <name>Technology detection using Wappalyzer</name>
+        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>wappalyzer-alpha-9.zap</file>
+        <status>alpha</status>
+        <changes>Updated Wappalyzer github link in help content.&lt;br&gt;
+	Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/wappalyzer-alpha-9.zap</url>
+        <hash>SHA1:81a5a935c80f8ed51eebcc401cd18da3cc18e799</hash>
+        <date>2017-11-24</date>
+        <size>1283522</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_wappalyzer>
+    <addon>webdriverlinux</addon>
+    <addon_webdriverlinux>
+        <name>Linux WebDrivers</name>
+        <description>Linux WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>webdriverlinux-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Update geckodriver to v0.19.1&lt;br&gt;
+	Update chromedriver to 2.33&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdriverlinux-beta-4.zap</url>
+        <hash>SHA1:85bd6f4960786ac28ca225e0325f7f4d6f30c64c</hash>
+        <date>2017-11-20</date>
+        <size>12848091</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_webdriverlinux>
+    <addon>webdrivermacos</addon>
+    <addon_webdrivermacos>
+        <name>MacOS WebDrivers</name>
+        <description>MacOS WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>webdrivermacos-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Update geckodriver to v0.19.1&lt;br&gt;
+	Update chromedriver to 2.33&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdrivermacos-beta-4.zap</url>
+        <hash>SHA1:2fb8f05781e5f3245f504ab45c7c2303e0b22d31</hash>
+        <date>2017-11-20</date>
+        <size>6751167</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_webdrivermacos>
+    <addon>webdriverwindows</addon>
+    <addon_webdriverwindows>
+        <name>Windows WebDrivers</name>
+        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>webdriverwindows-beta-4.zap</file>
+        <status>beta</status>
+        <changes>Update geckodriver to v0.19.1&lt;br&gt;
+	Update chromedriver to 2.33&lt;br&gt;
+	Update IEDriverServer to 3.7.0&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdriverwindows-beta-4.zap</url>
+        <hash>SHA1:5ea6424eadf1b2128d55b4c8976fb42a9e314de0</hash>
+        <date>2017-11-20</date>
+        <size>10340638</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_webdriverwindows>
     <addon>websocket</addon>
     <addon_websocket>
         <name>WebSockets</name>
@@ -380,420 +1391,6 @@
         <size>849497</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_websocket>
-
-    <addon>alertFilters</addon>
-    <addon_alertFilters>
-        <name>Context Alert Filters</name>
-        <description>Allows you to automate the changing of alert risk levels.</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>alertFilters-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Dynamically unload the add-on.&lt;br&gt;
-	Clear filters on session changes (Issue 3683).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/alertFilters-beta-5.zap</url>
-        <hash>SHA1:30ca048b72f3c6de3c011ab00bdb7c8822dedda0</hash>
-        <date>2017-11-24</date>
-        <size>285973</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_alertFilters>
-    
-    <addon>alertReport</addon>
-    <addon_alertReport>
-        <name>Report alert generator</name>
-        <description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
-        <author>Talsoft SRL</author>
-        <version>14</version>
-        <file>alertReport-beta-14.zap</file>
-        <status>beta</status>
-        <changes>Fix an exception while generating the report (Issue 1612).&lt;br&gt;
-	Include Alert's evidence in report of ODT format.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/alertReport-beta-14.zap</url>
-        <hash>SHA1:d5f2a410eafec455e4b1051eb68d7d6560c68be5</hash>
-        <info>http://www.talsoft.com.ar</info>
-        <date>2016-06-02</date>
-        <size>9712171</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_alertReport>
-    
-    <addon>ascanrulesBeta</addon>
-    <addon_ascanrulesBeta>
-        <name>Active scanner rules (beta)</name>
-        <description>The beta quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>22</version>
-        <file>ascanrulesBeta-beta-22.zap</file>
-        <status>beta</status>
-        <changes>Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).&lt;br&gt;
-	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).&lt;br&gt;
-	Support security annotations for forms that dont need anti-CSRF tokens.&lt;br&gt;
-	Changed XXE rule to use new callback extension.&lt;br&gt;
-	Notify of messages sent during Heartbleed scanning (Issue 2425).&lt;br&gt;
-	Fix false positive in Code Disclosure - CVE-2012-1823 on image content (Issue 3846).&lt;br&gt;
-	Fix false positive in Backup File Disclosure scanner on 403 responses (Issue 3911).&lt;br&gt;
-	CsrfTokenScan : Keep session cookies instead of deleting all of them&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/ascanrulesBeta-beta-22.zap</url>
-        <hash>SHA1:6c764624a8c3ddbdc47d0b5276244f3681a5c060</hash>
-        <date>2017-11-24</date>
-        <size>2762546</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_ascanrulesBeta>
-    
-    <addon>beanshell</addon>
-    <addon_beanshell>
-        <name>BeanShell Console</name>
-        <description>Provides a BeanShell Console</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>beanshell-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/beanshell-beta-5.zap</url>
-        <hash>SHA1:1fc34a12180cd700cc6fad2236641936cece8cdc</hash>
-        <date>2016-06-02</date>
-        <size>562333</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_beanshell>
-    
-    <addon>bruteforce</addon>
-    <addon_bruteforce>
-        <name>Forced Browse</name>
-        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>bruteforce-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Allow to set higher number of threads (Issue 2912).&lt;br&gt;
-    Fix issue with multiple concurrent scans.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/bruteforce-beta-6.zap</url>
-        <hash>SHA1:5acad406b5d9abe8cf88b8c67eb9b7b9a4c8a5b0</hash>
-        <date>2017-04-03</date>
-        <size>1000348 </size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_bruteforce>
-    
-    <addon>diff</addon>
-    <addon_diff>
-        <name>Diff</name>
-        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>diff-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/diff-beta-7.zap</url>
-        <hash>SHA1:1a7cb9e64e0740d752280729dda4c3f606c29a6c</hash>
-        <date>2017-04-03</date>
-        <size>235040</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_diff>
-    
-    <addon>fuzz</addon>
-    <addon_fuzz>
-        <name>AdvFuzzer</name>
-        <description>Advanced fuzzer for manual testing</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <semver>2.0.1</semver>
-        <file>fuzz-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-    Ignore empty payloads when highlighting or detecting reflections.&lt;br&gt;
-    Contains new number generator payload.&lt;br&gt;
-    Add null/empty payload generator.&lt;br&gt;
-    Issue 3557: Backport export changes.&lt;br&gt;    
-    Set fuzzer script types enabled by default (Issue 2997).&lt;br&gt;
-    Add description to script types.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/fuzz-beta-9.zap</url>
-        <hash>SHA1:56c15b8da1e19909ecc7fe06f29c6ba6b1c7f291</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
-        <date>2017-11-24</date>
-        <size>2400821</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_fuzz>
-    
-    <addon>importurls</addon>
-    <addon_importurls>
-        <name>Import files containing URLs</name>
-        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>importurls-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Minor change to help content.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importurls-beta-4.zap</url>
-        <hash>SHA1:e3df25f154a3a2001a8afffabebae9bf0a066416</hash>
-        <date>2017-11-24</date>
-        <size>223832</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_importurls>
-    
-    <addon>invoke</addon>
-    <addon_invoke>
-        <name>Invoke Applications</name>
-        <description>Invoke external applications passing context related information such as URLs and parameters</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>invoke-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Report/log when the application fails to start (related to Issue 3960).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/invoke-beta-7.zap</url>
-        <hash>SHA1:311a21e7ae14d996422bf48813c3b10602a98e00</hash>
-        <date>2017-10-19</date>
-        <size>291274</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_invoke>
-    
-    <addon>jruby</addon>
-    <addon_jruby>
-        <name>Ruby scripting</name>
-        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>jruby-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Add template for HTTP Sender script.&lt;br&gt;
-    Dynamically unload the add-on.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jruby-beta-5.zap</url>
-        <hash>SHA1:30920fbda214b6dea5dbf77a0f8c397cb38f2782</hash>
-        <date>2017-09-28</date>
-        <size>22471619</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jruby>
-    
-    <addon>jython</addon>
-    <addon_jython>
-        <name>Python scripting</name>
-        <description>Allows Python to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>jython-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Do not initialise java.awt.Toolkit when in daemon.&lt;br&gt;
-	Update HTTP Sender template with initiator ID of AJAX Spider.&lt;br&gt;
-	Added extender template and example.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jython-beta-7.zap</url>
-        <hash>SHA1:00e03758368f562d26ba135155a39f1976b003cc</hash>
-        <date>2017-10-27</date>
-        <size>41727201</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_jython>
-    
-    <addon>plugnhack</addon>
-    <addon_plugnhack>
-        <name>Plug-n-Hack Configuration</name>
-        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>plugnhack-beta-10.zap</file>
-        <status>beta</status>
-        <changes>Make breakpoint dialogues modal.&lt;br&gt;
-    Changed to use api nonces and include new fx_pnh.xpi (still unsigned).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/plugnhack-beta-10.zap</url>
-        <hash>SHA1:a71447529ca963139d454e940eff2a8ef4625dde</hash>
-        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
-        <date>2017-06-20</date>
-        <size>692662</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_plugnhack>
-    
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>portscan-beta-8.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/portscan-beta-8.zap</url>
-        <hash>SHA1:8c3c025534e804eede8d26fb3d5febec51059d96</hash>
-        <date>2017-11-24</date>
-        <size>633257</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_portscan>
-    
-    <addon>pscanrulesBeta</addon>
-    <addon_pscanrulesBeta>
-        <name>Passive scanner rules (beta)</name>
-        <description>The beta quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>17</version>
-        <file>pscanrulesBeta-beta-17.zap</file>
-        <status>beta</status>
-        <changes>Minor changes to InsecureJFSViewStatePassiveScanner (check response contains JSF viewstate or if it's server stored).&lt;br/&gt;
-	Improve the domain matching in CookieLooselyScopedScanner.&lt;br/&gt;
-	Issue 3449: CSRFcountermeasures passive scanner now raises alerts on a per-form basis on pages with multiple forms.&lt;br/&gt; 
-	Issue 3937: Update ServletParameterPollutionScanner reference.&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/pscanrulesBeta-beta-17.zap</url>
-        <hash>SHA1:7d1870ff53c1b9ea361d8033ca203c9cec9d5e93</hash>
-        <date>2017-11-24</date>
-        <size>557020</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_pscanrulesBeta>
-    
-    <addon>scripts</addon>
-    <addon_scripts>
-        <name>Script Console</name>
-        <description>Supports all JSR 223 scripting languages</description>
-        <author>ZAP Dev Team</author>
-        <version>21</version>
-        <file>scripts-beta-21.zap</file>
-        <status>beta</status>
-        <changes>Show script types in alphabetical order in dialogues New and Load Script.&lt;br&gt;
-	Fix an exception when installing extender scripts with errors.&lt;br&gt;
-	Correct state of Enabled checkbox when creating a script from templates.&lt;br&gt;
-	Allow to enable code folding in script text area.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/scripts-beta-21.zap</url>
-        <hash>SHA1:d98f881c4fc631d51c970b3d8f1bc3b2f212ab45</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
-        <date>2017-11-24</date>
-        <size>572335</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_scripts>
-    
-    <addon>sqliplugin</addon>
-    <addon_sqliplugin>
-        <name>Advanced SQLInjection Scanner</name>
-        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
-        <author>Andrea Pompili (Yhawke)</author>
-        <version>11</version>
-        <file>sqliplugin-beta-11.zap</file>
-        <status>beta</status>
-        <changes>Check all DB techs when evaluating if the scanner should be run.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sqliplugin-beta-11.zap</url>
-        <hash>SHA1:33b91ef51c3fb322efe14a8da56a77252760d392</hash>
-        <date>2016-07-07</date>
-        <size>104490</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_sqliplugin>
-    
-    <addon>svndigger</addon>
-    <addon_svndigger>
-        <name>SVN Digger files</name>
-        <description>SVN Digger files which can be used with ZAP forced browsing</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>svndigger-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/svndigger-beta-3.zap</url>
-        <hash>SHA1:257803a38ab33b7645deb63562d1fcce2c4fb46c</hash>
-        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
-        <date>2016-06-02</date>
-        <size>614846</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_svndigger>
-    
-    <addon>tips</addon>
-    <addon_tips>
-        <name>Tips and Tricks</name>
-        <description>Display ZAP Tips and Tricks</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>tips-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tips-beta-6.zap</url>
-        <hash>SHA1:ae835ec3e884148f1ff49daf6fc80d613e28e297</hash>
-        <date>2017-04-03</date>
-        <size>501880</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_tips>
-    
-    <addon>tokengen</addon>
-    <addon_tokengen>
-        <name>Token generation and analysis</name>
-        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
-        <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>tokengen-beta-11.zap</file>
-        <status>beta</status>
-        <changes>Use custom HTTP Sender initiator ID.&lt;br&gt;
-	Show same cookies once in Generate Tokens dialogue (Issue 2116).&lt;br&gt;
-	Fix exception when no tokens are found (Issue 2116).&lt;br&gt;
-	Added help file.&lt;br&gt;
-	Issue 2338: Allow dynamic timeout adjustment to combat read timeout issues.&lt;br&gt;
-	Ensure initial dialog is properly sized.&lt;br&gt;
-	Issue 2000: Title caps adjustments.&lt;br&gt;
-	Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Ensure Analyse Token dialogue is shown in front of main window.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tokengen-beta-11.zap</url>
-        <hash>SHA1:39b89cb4404a59b8df848e6f69cb74146d80c84e</hash>
-        <date>2017-11-24</date>
-        <size>478974</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_tokengen>
-    
-    <addon>treetools</addon>
-    <addon_treetools>
-        <name>TreeTools</name>
-        <description>Tools to add functionality to the tree view.</description>
-        <author>Carl Sampson</author>
-        <version>6</version>
-        <file>treetools-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Safe menu items will now be enabled in protected and safe modes (Issue 1278).</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/treetools-beta-6.zap</url>
-        <hash>SHA1:65dc679630d1d273cb4e8f541247d1deeff836e6</hash>
-        <date>2016-06-02</date>
-        <size>17636</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_treetools>
-    
-    <addon>webdriverlinux</addon>
-    <addon_webdriverlinux>
-        <name>Linux WebDrivers</name>
-        <description>Linux WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>webdriverlinux-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Update geckodriver to v0.19.1&lt;br&gt;
-	Update chromedriver to 2.33&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdriverlinux-beta-4.zap</url>
-        <hash>SHA1:85bd6f4960786ac28ca225e0325f7f4d6f30c64c</hash>
-        <date>2017-11-20</date>
-        <size>12848091</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_webdriverlinux>
-
-    <addon>webdrivermacos</addon>
-    <addon_webdrivermacos>
-        <name>MacOS WebDrivers</name>
-        <description>MacOS WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>webdrivermacos-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Update geckodriver to v0.19.1&lt;br&gt;
-	Update chromedriver to 2.33&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdrivermacos-beta-4.zap</url>
-        <hash>SHA1:2fb8f05781e5f3245f504ab45c7c2303e0b22d31</hash>
-        <date>2017-11-20</date>
-        <size>6751167</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_webdrivermacos>
-
-    <addon>webdriverwindows</addon>
-    <addon_webdriverwindows>
-        <name>Windows WebDrivers</name>
-        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>webdriverwindows-beta-4.zap</file>
-        <status>beta</status>
-        <changes>Update geckodriver to v0.19.1&lt;br&gt;
-	Update chromedriver to 2.33&lt;br&gt;
-	Update IEDriverServer to 3.7.0&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/webdriverwindows-beta-4.zap</url>
-        <hash>SHA1:5ea6424eadf1b2128d55b4c8976fb42a9e314de0</hash>
-        <date>2017-11-20</date>
-        <size>10340638</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_webdriverwindows>
-
     <addon>zest</addon>
     <addon_zest>
         <name>Zest - Graphical Security Scripting Language</name>
@@ -825,683 +1422,4 @@
             </addons>
         </dependencies>
     </addon_zest>
-	
-	<addon>accessControl</addon>
-    <addon_accessControl>
-        <name>Access Control Testing</name>
-        <description>Adds a set of tools for testing access control in web applications.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>accessControl-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Fix exception that occurred with Java 9 (Issue 3934).&lt;br&gt;
-	Allow to copy multiple results and copy correct value from the result column.&lt;br&gt;
-	Display correct message when the table is sorted.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/accessControl-alpha-3.zap</url>
-        <hash>SHA1:21f36dc3c4b6ebff10ac8fbb4f358b78b89328d0</hash>
-        <date>2017-11-24</date>
-        <size>512096</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_accessControl>
-    
-    <addon>amf</addon>
-    <addon_amf>
-        <name>AMF</name>
-        <description>Adds support for AMF messages</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>amf-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Deserialise the AMF request.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/amf-alpha-2.zap</url>
-        <hash>SHA1:e34f73753902f2ebedc0be130b446cae39ff4784</hash>
-        <date>2017-05-26</date>
-        <size>813478</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_amf>
-    
-    <addon>ascanrulesAlpha</addon>
-    <addon_ascanrulesAlpha>
-        <name>Active scanner rules (alpha)</name>
-        <description>The alpha quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>20</version>
-        <file>ascanrulesAlpha-alpha-20.zap</file>
-        <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Correct handling of messages with emtpy path.&lt;br&gt;
-	Add Get for Post Scanner.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/ascanrulesAlpha-alpha-20.zap</url>
-        <hash>SHA1:df085930d5a817a60a1dd98cb3beae5750916186</hash>
-        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</info>
-        <date>2017-11-24</date>
-        <size>1434903</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_ascanrulesAlpha>
-    
-    <addon>authstats</addon>
-    <addon_authstats>
-        <name>Authentication Statistics</name>
-        <description>Records logged in/out statistics for all contexts in scope.</description>
-        <author>ZAP Core Team</author>
-        <version>1</version>
-        <file>authstats-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>First version&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/authstats-alpha-1.zap</url>
-        <hash>SHA1:c00d7e572faba04ff1262bcc04406599a8b20ffd</hash>
-        <info>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAuthstatsAuthStats</info>
-        <date>2016-08-16</date>
-        <size>11605</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_authstats>
-
-    <addon>browserView</addon>
-    <addon_browserView>
-        <name>Browser View</name>
-        <description>Adds an option to render HTML responses like a browser</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>browserView-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Allow to properly scroll the rendered page.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/browserView-alpha-5.zap</url>
-        <hash>SHA1:6acfc72f0491d3b391d6633b3dc89ad6d4d4c801</hash>
-        <date>2017-07-21</date>
-        <size>188142</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_browserView>
-    
-    <addon>bugtracker</addon>
-    <addon_bugtracker>
-        <name>Bug Tracker</name>
-        <description>Bug Tracker extension.</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>bugtracker-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Added help for the add-on</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/bugtracker-alpha-2.zap</url>
-        <hash>SHA1:156b7ad6616db6a17d96ecea42c44542e5bbf163</hash>
-        <date>2017-05-26</date>
-        <size>1995812</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_bugtracker>
-    
-    <addon>callgraph</addon>
-    <addon_callgraph>
-        <name>Call Graph</name>
-        <description>Allows the user to view a call graph of the selected resources</description>
-        <author>Colm O'Flaherty</author>
-        <version>4</version>
-        <file>callgraph-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Finish internationalisation.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/callgraph-alpha-4.zap</url>
-        <hash>SHA1:c369e9bc5c18800debe566595cdc73cc7a7f4629</hash>
-        <date>2017-11-24</date>
-        <size>1158457</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_callgraph>
-    
-    <addon>codedx</addon>
-    <addon_codedx>
-        <name>Code Dx Extension</name>
-        <description>Includes request and response data in XML reports and provides the ability to upload reports directly to a Code Dx server</description>
-        <author>Code Dx, Inc.</author>
-        <version>5</version>
-        <file>codedx-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Add an upload to Code Dx option.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/codedx-alpha-5.zap</url>
-        <hash>SHA1:fad5d14acd070d6ab2b7baae7092a5f75f5b6a8c</hash>
-        <date>2017-04-18</date>
-        <size>1185698</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_codedx>
-    
-    <addon>communityScripts</addon>
-    <addon_communityScripts>
-        <name>Community Scripts</name>
-        <description>Useful ZAP scripts written by the ZAP community.</description>
-        <author>ZAP Community</author>
-        <version>4</version>
-        <file>communityScripts-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated with the latest scripts for 2.6.0&lt;br&gt;
-	Stop the scripts from being registered twice&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/communityScripts-alpha-4.zap</url>
-        <hash>SHA1:822bb272b10cf3f185e92f297dec1ffe3ca142bb</hash>
-        <info>https://github.com/zaproxy/community-scripts</info>
-        <date>2017-10-17</date>
-        <size>335736</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_communityScripts>
-    
-    <addon>cspscanner</addon>
-    <addon_cspscanner>
-        <name>Content Security Policy Scanner</name>
-        <description>Content Security Policy (CSP) Scanner</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>cspscanner-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Fixed missing error and warning messages.&lt;br&gt;
-		Added evidence.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/cspscanner-alpha-4.zap</url>
-        <hash>SHA1:1d672d3575e395c5bd466274979338a5ece2d965</hash>
-        <date>2017-07-27</date>
-        <size>112917</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_cspscanner>
-
-    <addon>customreport</addon>
-    <addon_customreport>
-        <name>CustomReport</name>
-        <description>New HTML report module allows users to customize report content.</description>
-        <author>Chienli Ma</author>
-        <version>2</version>
-        <file>customreport-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/customreport-alpha-2.zap</url>
-        <hash>SHA1:fe8f172a879e5372d040449973ac7a1a133eafd5</hash>
-        <date>2016-06-02</date>
-        <size>557158</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_customreport>
-    
-    <addon>domxss</addon>
-    <addon_domxss>
-        <name>DOM XSS Active scanner rule</name>
-        <description>DOM XSS Active scanner rule</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>domxss-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Allow to use newer versions of Firefox (Issue 3396).&lt;br&gt;
-	Provide the reason why the scanner was skipped.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/domxss-alpha-4.zap</url>
-        <hash>SHA1:031676c8d795251f94c8c57c645f2de236b69551</hash>
-        <date>2017-08-18</date>
-        <size>193882</size>
-        <not-before-version>2.6.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>2.*</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_domxss>
-    
-    <addon>help_bs_BA</addon>
-    <addon_help_bs_BA>
-        <name>Help - Bosnian</name>
-        <description>Bosnian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>6</version>
-        <file>help_bs_BA-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.6.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_bs_BA-alpha-6.zap</url>
-        <hash>SHA1:8f54f0fe065762f101ee1818545dacca581b2a2c</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2017-11-24</date>
-        <size>773399</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_help_bs_BA>
-    
-    <addon>help_es_ES</addon>
-    <addon_help_es_ES>
-        <name>Help - Spanish</name>
-        <description>Spanish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>6</version>
-        <file>help_es_ES-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.6.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_es_ES-alpha-6.zap</url>
-        <hash>SHA1:5055f43457c118363b828a6e83a036e4b5b13d52</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2017-11-24</date>
-        <size>775922</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_help_es_ES>
-    
-    <addon>help_fr_FR</addon>
-    <addon_help_fr_FR>
-        <name>Help - French</name>
-        <description>French version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>6</version>
-        <file>help_fr_FR-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.6.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_fr_FR-alpha-6.zap</url>
-        <hash>SHA1:d2946f64199d1b4dad767f86ae92b408fa61c66f</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2017-11-24</date>
-        <size>773836</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_help_fr_FR>
-    
-    <addon>help_ja_JP</addon>
-    <addon_help_ja_JP>
-        <name>Help - Japanese</name>
-        <description>Japanese version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>6</version>
-        <file>help_ja_JP-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.6.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/help_ja_JP-alpha-6.zap</url>
-        <hash>SHA1:50cf8563f1bd97f9cc3c9e90132057b5a6f8d484</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2017-11-24</date>
-        <size>799759</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_help_ja_JP>
-    
-    <addon>highlighter</addon>
-    <addon_highlighter>
-        <name>Highlighter</name>
-        <description>Allows you to highlight strings in the request and response tabs.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>highlighter-alpha-6.zap</file>
-        <status>alpha</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/highlighter-alpha-6.zap</url>
-        <hash>SHA1:ebc48b0880ff7862839ae0158de9ddb038218735</hash>
-        <date>2016-06-02</date>
-        <size>9568</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_highlighter>
-    
-    <addon>httpsInfo</addon>
-    <addon_httpsInfo>
-        <name>HttpsInfo</name>
-        <description>Displays HTTPS configuration information.</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>httpsInfo-alpha-10.zap</file>
-        <status>alpha</status>
-        <changes>Upgrade to use DeepViolet 5.0.3, which provides some minor logging changes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/httpsInfo-alpha-10.zap</url>
-        <hash>SHA1:1f862f891f7a6aebf474c654547b98ffcb8651bf</hash>
-        <date>2017-11-24</date>
-        <size>5545558</size>
-        <not-before-version>2.4.0</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_httpsInfo>
-    
-    <addon>importLogFiles</addon>
-    <addon_importLogFiles>
-        <name>Log File Importer</name>
-        <description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>importLogFiles-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Use API actions when importing files.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/importLogFiles-alpha-4.zap</url>
-        <hash>SHA1:ed557f0caf1e7c630532d9171f13f8afaa99be30</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs</info>
-        <date>2017-05-05</date>
-        <size>152363</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_importLogFiles>
-
-    <addon>jxbrowser</addon>
-    <addon_jxbrowser>
-        <name>JxBrowser (core)</name>
-        <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>jxbrowser-alpha-7.zap</file>
-        <status>alpha</status>
-        <changes>Updated to JxBrowser 6.17.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowser-alpha-7.zap</url>
-        <hash>SHA1:661745f3809e80bc72251a5eebc21c98441f0eec</hash>
-        <date>2017-11-20</date>
-        <size>1412665</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_jxbrowser>
-
-    <addon>jxbrowserlinux32</addon>
-    <addon_jxbrowserlinux32>
-        <name>JxBrowser (Linux 32)</name>
-        <description>An embedded browser based on Chromium, Linux 32 specific</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>jxbrowserlinux32-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.14.2.&lt;br&gt;
-		Updated to support latest selenium interfaces.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux32-alpha-3.zap</url>
-        <hash>SHA1:ac8303a826fafe4df75ef348b5d2f7ce1f134cb6</hash>
-        <date>2017-08-18</date>
-        <size>47149067</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverlinux</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserlinux32>
-
-    <addon>jxbrowserlinux64</addon>
-    <addon_jxbrowserlinux64>
-        <name>JxBrowser (Linux 64)</name>
-        <description>An embedded browser based on Chromium, Linux 64 specific</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jxbrowserlinux64-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserlinux64-alpha-4.zap</url>
-        <hash>SHA1:db770aa5b37d386c142ba1943a6b2928dbf6cd23</hash>
-        <date>2017-11-20</date>
-        <size>52750394</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverlinux</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserlinux64>
-
-    <addon>jxbrowsermacos</addon>
-    <addon_jxbrowsermacos>
-        <name>JxBrowser (Mac OS)</name>
-        <description>An embedded browser based on Chromium, Mac OS specific</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jxbrowsermacos-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowsermacos-alpha-4.zap</url>
-        <hash>SHA1:a57a6d297feda6e842b5756685f19bbf3b31ca95</hash>
-        <date>2017-11-20</date>
-        <size>56486892</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdrivermacos</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowsermacos>
-
-    <addon>jxbrowserwindows</addon>
-    <addon_jxbrowserwindows>
-        <name>JxBrowser (Windows)</name>
-        <description>An embedded browser based on Chromium, Windows specific</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>jxbrowserwindows-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for JxBrowser 6.17&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/jxbrowserwindows-alpha-4.zap</url>
-        <hash>SHA1:3cdbaa964a2fea7b6c9d7fc696253d6a90eb46b1</hash>
-        <date>2017-11-20</date>
-        <size>36680513</size>
-        <not-before-version>2.5.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>jxbrowser</id>
-                </addon>
-                <addon>
-                    <id>webdriverwindows</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_jxbrowserwindows>
-    
-    <addon>openapi</addon>
-    <addon_openapi>
-        <name>OpenAPI Support</name>
-        <description>Imports and spiders Open API definitions.</description>
-        <author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
-        <version>8</version>
-        <file>openapi-alpha-8.zap</file>
-        <status>alpha</status>
-        <changes>Fix NPE in BodyGenerator.&lt;br&gt;
-		Fix NPEs when a parameter is null.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/openapi-alpha-8.zap</url>
-        <hash>SHA1:c28949de9794a974ff54864a54970d9a4ae0612e</hash>
-        <date>2017-11-24</date>
-        <size>3171797</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_openapi>
-    
-    <addon>pscanrulesAlpha</addon>
-    <addon_pscanrulesAlpha>
-        <name>Passive scanner rules (alpha)</name>
-        <description>The alpha quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>18</version>
-        <file>pscanrulesAlpha-alpha-18.zap</file>
-        <status>alpha</status>
-        <changes>Correct typo in XCOLD alert description (Issue 3997).&lt;br&gt;
-	Do not set a value in the attack fields.&lt;br&gt;
-	Do not rely on system's charset to create request/response bodies.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/pscanrulesAlpha-alpha-18.zap</url>
-        <hash>SHA1:c8ec9c62c2d94e52d36b14cd586eb5d5c0b31e20</hash>
-        <date>2017-11-24</date>
-        <size>2214618</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_pscanrulesAlpha>
-    
-    <addon>replacer</addon>
-    <addon_replacer>
-        <name>Replacer</name>
-        <description>Easy way to replace strings in requests and responses.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>replacer-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Added API support</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/replacer-beta-3.zap</url>
-        <hash>SHA1:9bfa4d030c8ab519f05250dc57af1e194a8563a0</hash>
-        <date>2017-06-23</date>
-        <size>283688</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_replacer>
-
-    <addon>requester</addon>
-    <addon_requester>
-        <name>Requester</name>
-        <description>Request numbered panel.</description>
-        <author>Surikato</author>
-        <version>1</version>
-        <file>requester-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/requester-alpha-1.zap</url>
-        <hash>SHA1:3f43ac40b5b6225ebdc918df0b14cd53f0e7e8a2</hash>
-        <date>2016-06-02</date>
-        <size>40411</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_requester>
-    
-    <addon>revisit</addon>
-    <addon_revisit>
-        <name>Revisit</name>
-        <description>Revisit a site at any time in the past using the session history</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>revisit-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Allow to update/uninstall the add-on without restarting ZAP.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/revisit-alpha-2.zap</url>
-        <hash>SHA1:84087ce758254bc515160b458bcf5c2c82773641</hash>
-        <date>2016-06-02</date>
-        <size>279982</size>
-        <not-before-version>2.4.2</not-before-version>
-    </addon_revisit>
-    
-    <addon>saml</addon>
-    <addon_saml>
-        <name>SAML Extension</name>
-        <description>Detect, Show, Edit, Fuzz SAML requests</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>saml-alpha-7.zap</file>
-        <status>alpha</status>
-        <changes>Minor code change to work with ZAP 2.5.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/saml-alpha-7.zap</url>
-        <hash>SHA1:47e830cfffbe0742440f9923356ed73f3e817074</hash>
-        <info>https://github.com/zaproxy/zaproxy</info>
-        <date>2017-11-24</date>
-        <size>997657</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_saml>
-    
-    <addon>sequence</addon>
-    <addon_sequence>
-        <name>Sequence</name>
-        <description>Gives the possibility of defining a sequence of requests to be scanned.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>sequence-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Correct error message to include the script name.&lt;br&gt;
-    Add help content (Issue 2191).&lt;br&gt;
-    Depend on Zest extension, since it is currently the only script option for Sequence scripts.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/sequence-alpha-4.zap</url>
-        <hash>SHA1:734c30eddc68fa938e9f7eedb8d3284c255b5038</hash>
-        <date>2017-05-25</date>
-        <size>1319013</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>zest</id>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_sequence>
-    
-    <addon>sniTerminator</addon>
-    <addon_sniTerminator>
-        <name>SNI Terminator</name>
-        <description>Transparent HTTP proxying</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>sniTerminator-alpha-5.zap</file>
-        <status>alpha</status>
-        <changes>Minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/sniTerminator-alpha-5.zap</url>
-        <hash>SHA1:e84387ae6343989c2d1d943797c22c5f1bf990c2</hash>
-        <info>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</info>
-        <date>2017-11-24</date>
-        <size>254816</size>
-        <not-before-version>2.4.1</not-before-version>
-        <dependencies>
-            <javaversion>1.8</javaversion>
-        </dependencies>
-    </addon_sniTerminator>
-    
-    <addon>soap</addon>
-    <addon_soap>
-        <name>SOAP Scanner</name>
-        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
-        <author>Alberto (albertov91) + ZAP Core team</author>
-        <version>3</version>
-        <file>soap-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Added API, help and other minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/soap-alpha-3.zap</url>
-        <hash>SHA1:c02815ca249e8d2736d9e66498bfe7d43ed0d464</hash>
-        <date>2017-03-31</date>
-        <size>7337575</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_soap>
-    
-    <addon>sse</addon>
-    <addon_sse>
-        <name>Server-Sent Events</name>
-        <description>Allows you to view Server-Sent Events (SSE) communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>sse-alpha-9.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/sse-alpha-9.zap</url>
-        <hash>SHA1:c642ed5fa03bc2c7840c722baf9dc9d842197e9d</hash>
-        <date>2016-06-02</date>
-        <size>331696</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_sse>
-
-    <addon>tlsdebug</addon>
-    <addon_tlsdebug>
-        <name>TLS Debug</name>
-        <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
-        <author>P.M.J. Roth</author>
-        <version>2</version>
-        <file>tlsdebug-alpha-2.zap</file>
-        <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/tlsdebug-alpha-2.zap</url>
-        <hash>SHA1:813cedda7bf5afe7c0b12ca0b520a11fc0829805</hash>
-        <date>2017-11-24</date>
-        <size>234477</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_tlsdebug>
-    
-    <addon>viewstate</addon>
-    <addon_viewstate>
-        <name>ViewState</name>
-        <description>ASP/JSF ViewState Decoder and Editor</description>
-        <author>Calum Hutton</author>
-        <version>1</version>
-        <file>viewstate-alpha-1.zap</file>
-        <status>alpha</status>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.5/viewstate-alpha-1.zap</url>
-        <hash>SHA1:55decd0f02e3a75bcc8e6f3ce757d569e398a099</hash>
-        <date>2016-09-14</date>
-        <size>25184</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_viewstate>
-    
-    <addon>wappalyzer</addon>
-    <addon_wappalyzer>
-        <name>Technology detection using Wappalyzer</name>
-        <description>Technology detection using Wappalyzer: wappalyzer.com</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>wappalyzer-alpha-9.zap</file>
-        <status>alpha</status>
-        <changes>Updated Wappalyzer github link in help content.&lt;br&gt;
-	Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.6/wappalyzer-alpha-9.zap</url>
-        <hash>SHA1:81a5a935c80f8ed51eebcc401cd18da3cc18e799</hash>
-        <date>2017-11-24</date>
-        <size>1283522</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_wappalyzer>
-	
 </ZAP>

--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -1,424 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
-	
-    <addon>ascanrules</addon>
-    <addon_ascanrules>
-        <name>Active scanner rules</name>
-        <description>The release quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>31</version>
-        <file>ascanrules-release-31.zap</file>
-        <status>release</status>
-        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
-    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
-    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
-        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
-        <date>2018-03-05</date>
-        <size>635944</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_ascanrules>
-
-    <addon>attacksurfacedetector</addon>
-    <addon_attacksurfacedetector>
-        <name>Attack Surface Detector</name>
-        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
-        <author>Secure Decisions (Matthew DeLetto)</author>
-        <version>1.1.1</version>
-        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
-        <status>alpha</status>
-        <changes>First Version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
-        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
-        <date>2018-06-28</date>
-        <size>14387774</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_attacksurfacedetector>
-    
-    <addon>coreLang</addon>
-    <addon_coreLang>
-        <name>Core Language Files</name>
-        <description>Translations of the core language files</description>
-        <author>ZAP Dev Team</author>
-        <version>13</version>
-        <file>coreLang-release-13.zap</file>
-        <status>release</status>
-        <changes>Added help file with credits.&lt;br&gt;
-	Updated the languages files from Crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/coreLang-release-13.zap</url>
-        <hash>SHA1:8074521b78c3fc9d63e0543ca3887afa2424167e</hash>
-        <info>https://crowdin.com/project/owasp-zap</info>
-        <date>2018-01-15</date>
-        <size>3221988</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_coreLang>
-    
-    <addon>directorylistv1</addon>
-    <addon_directorylistv1>
-        <name>Directory List v1.0</name>
-        <description>List of directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv1-release-3.zap</file>
-        <status>release</status>
-        <changes>Removed repeated files.&lt;br&gt;
-	Added strings for version control directories of Git, Mercurial, SVN, CVS, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv1-release-3.zap</url>
-        <hash>SHA1:b1697b64f5bc50f6bfcb4047b37789850cc3e252</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>847619</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv1>
-    
-    <addon>directorylistv2_3</addon>
-    <addon_directorylistv2_3>
-        <name>Directory List v2.3</name>
-        <description>Lists of directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv2_3-release-3.zap</file>
-        <status>release</status>
-        <changes>Removed repeated files.&lt;br&gt;
-	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3-release-3.zap</url>
-        <hash>SHA1:e3b9cb6a9bae87a0dbcf73ff52f7b4406486d5c0</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>8608734</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv2_3>
-    
-    <addon>directorylistv2_3_lc</addon>
-    <addon_directorylistv2_3_lc>
-        <name>Directory List v2.3 LC</name>
-        <description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv2_3_lc-release-3.zap</file>
-        <status>release</status>
-        <changes>Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3_lc-release-3.zap</url>
-        <hash>SHA1:03a5ec11530203be6625633821ab3c05754b2daa</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>7454767</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv2_3_lc>
-    
-    <addon>fuzzdb</addon>
-    <addon_fuzzdb>
-        <name>FuzzDB files</name>
-        <description>FuzzDB files which can be used with the ZAP fuzzer</description>
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
+    <addon>accessControl</addon>
+    <addon_accessControl>
+        <name>Access Control Testing</name>
+        <description>Adds a set of tools for testing access control in web applications.</description>
         <author>ZAP Dev Team</author>
         <version>4</version>
-        <file>fuzzdb-release-4.zap</file>
-        <status>release</status>
-        <changes>Update FuzzDB files.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzzdb-release-4.zap</url>
-        <hash>SHA1:6da7ce962bae6b54954415eb71059467e93f14f6</hash>
-        <info>https://github.com/fuzzdb-project/fuzzdb/</info>
-        <date>2017-11-27</date>
-        <size>5627107</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_fuzzdb>
-    
-    <addon>gettingStarted</addon>
-    <addon_gettingStarted>
-        <name>Getting Started with ZAP Guide</name>
-        <description>A short Getting Started with ZAP Guide</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>gettingStarted-release-9.zap</file>
-        <status>release</status>
-        <changes>Added the Spanish, Filipino and Indonesian translations</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/gettingStarted-release-9.zap</url>
-        <hash>SHA1:85108d1ae8df5baae37e62a8494d774a32268782</hash>
-        <date>2018-02-13</date>
-        <size>1623605</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_gettingStarted>
-
-    <addon>groovy</addon>
-    <addon_groovy>
-        <name>Groovy Scripting</name>
-        <description>Allows Groovy to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>groovy-alpha-2.zap</file>
+        <file>accessControl-alpha-4.zap</file>
         <status>alpha</status>
-        <changes>Add help.&lt;br&gt;
-    Added script templates.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/groovy-alpha-2.zap</url>
-        <hash>SHA1:7f0d54eaf987a435e941a422378c124f3fd29259</hash>
-        <date>2018-04-19</date>
-        <size>7334399</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_groovy>
-    
-    <addon>help</addon>
-    <addon_help>
-        <name>Help - English</name>
-        <description>English (master) version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>8</version>
-        <file>help-release-8.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help-release-8.zap</url>
-        <hash>SHA1:137c6627366d86e4629d32aa066e0ebf457ebfe3</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpIntro</info>
-        <date>2017-11-27</date>
-        <size>725234</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help>
-    
-    <addon>help_es_ES</addon>
-    <addon_help_es_ES>
-        <name>Help - Spanish</name>
-        <description>Spanish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>9</version>
-        <file>help_es_ES-release-9.zap</file>
-        <status>release</status>
-        <changes>Updated with the latest files from crowdin, promoted to release</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_es_ES-release-9.zap</url>
-        <hash>SHA1:c17a1d63de54a99feb5344ea3f07e66dcbd7d4d1</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>810573</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_es_ES>
-
-    <addon>help_pt_BR</addon>
-    <addon_help_pt_BR>
-        <name>Help - Portuguese, Brazilian</name>
-        <description>Portuguese, Brazilian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>10</version>
-        <file>help_pt_BR-release-10.zap</file>
-        <status>release</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_pt_BR-release-10.zap</url>
-        <hash>SHA1:43ef048b4faff32e6ed59dfbd07174ceec71bbdb</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>793044</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_pt_BR>
-
-    <addon>help_tr_TR</addon>
-    <addon_help_tr_TR>
-        <name>Help - Turkish</name>
-        <description>Turkish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>1</version>
-        <file>help_tr_TR-release-1.zap</file>
-        <status>release</status>
-        <changes>First version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_tr_TR-release-1.zap</url>
-        <hash>SHA1:2d4c3c115e0f401c37049dd1802f413b42f88e5e</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>815439</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_tr_TR>
-    
-    <addon>onlineMenu</addon>
-    <addon_onlineMenu>
-        <name>Online menus</name>
-        <description>ZAP Online menu items</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>onlineMenu-release-6.zap</file>
-        <status>release</status>
         <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/onlineMenu-release-6.zap</url>
-        <hash>SHA1:343c6f9891b311739770bbb3e25d12c766bd1866</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</info>
-        <date>2017-11-27</date>
-        <size>206306</size>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/accessControl-alpha-4.zap</url>
+        <hash>SHA1:c5e590e41dfeec29026956a1e08c0f8b024c0dc4</hash>
+        <date>2017-11-28</date>
+        <size>513559</size>
         <not-before-version>2.7.0</not-before-version>
-    </addon_onlineMenu>
-    
-    <addon>pscanrules</addon>
-    <addon_pscanrules>
-        <name>Passive scanner rules</name>
-        <description>The release quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>22</version>
-        <file>pscanrules-release-22.zap</file>
-        <status>release</status>
-        <changes>Retired the password auto-complete passive scan rule (Issue 4215).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrules-release-22.zap</url>
-        <hash>SHA1:3a3203bcbca8b9091baf12bb5ddf4ec192a15295</hash>
-        <date>2018-01-19</date>
-        <size>518316</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_pscanrules>
-    
-    <addon>quickstart</addon>
-    <addon_quickstart>
-        <name>Quick Start</name>
-        <description>Provides a tab which allows you to quickly test a target application</description>
-        <author>ZAP Dev Team</author>
-        <version>23</version>
-        <file>quickstart-release-23.zap</file>
-        <status>release</status>
-        <changes>Update for 2.7.0.&lt;br&gt;
-    Stop the quick scan if the session is changed.&lt;br&gt;
-    Added toolbar button to launch the latest browser chosen.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/quickstart-release-23.zap</url>
-        <hash>SHA1:34aed4c9a93220978799aff7002236a669c02b25</hash>
-        <date>2018-01-19</date>
-        <size>436181</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_quickstart>
-    
-    <addon>reveal</addon>
-    <addon_reveal>
-        <name>Reveal</name>
-        <description>Show hidden fields and enable disabled fields</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>reveal-release-2.zap</file>
-        <status>release</status>
-        <changes>Code changes and API documentation.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/reveal-release-2.zap</url>
-        <hash>SHA1:caec390697cdc2c82945371e80901af05cc2bfbc</hash>
-        <date>2017-11-27</date>
-        <size>230262</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_reveal>
-    
-    <addon>saverawmessage</addon>
-    <addon_saverawmessage>
-        <name>Save Raw Message</name>
-        <description>Allows to save content of HTTP messages as binary</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>saverawmessage-release-4.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/saverawmessage-release-4.zap</url>
-        <hash>SHA1:df600792159042a452e3e9215d9b89b21417bf88</hash>
-        <date>2017-11-27</date>
-        <size>27756</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_saverawmessage>
-
-    <addon>savexmlmessage</addon>
-    <addon_savexmlmessage>
-        <name>Save XML Message</name>
-        <description>Allows to save content of HTTP messages as XML</description>
-        <author>thatsn0tmysite</author>
-        <version>0.0.1</version>
-        <file>savexmlmessage-alpha-0.0.1.zap</file>
-        <status>alpha</status>
-        <changes>Initial release.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/savexmlmessage-alpha-0.0.1.zap</url>
-        <hash>SHA1:5a819610819e4edc227df5da4dac3c886f2b2d29</hash>
-        <date>2018-05-30</date>
-        <size>12873</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_savexmlmessage>
-    
-    <addon>selenium</addon>
-    <addon_selenium>
-        <name>Selenium</name>
-        <description>WebDriver provider and includes HtmlUnit browser</description>
-        <author>ZAP Dev Team</author>
-        <version>13</version>
-        <semver>2.0.0</semver>
-        <file>selenium-release-13.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/selenium-release-13.zap</url>
-        <hash>SHA1:27805e3b31a189d0377d359d0c9551dc820adde0</hash>
-        <date>2017-11-27</date>
-        <size>22796677</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_selenium>
-    
-    <addon>spiderAjax</addon>
-    <addon_spiderAjax>
-        <name>Ajax Spider</name>
-        <description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
-        <author>ZAP Dev Team</author>
-        <version>21</version>
-        <file>spiderAjax-release-21.zap</file>
-        <status>release</status>
-        <changes>Reset API scan also when in daemon mode (Issue 4163).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/spiderAjax-release-21.zap</url>
-        <hash>SHA1:92f5a3ecded1d5e0f3b889b07656f5ec8414ada0</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</info>
-        <date>2018-01-19</date>
-        <size>2597145</size>
-        <not-before-version>2.7.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>2.*</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_spiderAjax>
-    
-    <addon>websocket</addon>
-    <addon_websocket>
-        <name>WebSockets</name>
-        <description>Allows you to inspect WebSocket communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>16</version>
-        <file>websocket-release-16.zap</file>
-        <status>release</status>
-        <changes>Tweak About help page.&lt;br&gt;
-    Remove event consumers when the channel is closed.&lt;br&gt;
-    Don't enable the sender scripts by default.&lt;br&gt;
-    Fix send of CLOSE messages with message editor (Issue 4657).&lt;br&gt;
-    Add missing error message.&lt;br&gt;
-    Fix removal of pop up menu items.&lt;br&gt;
-    Allow to filter by payload in WebSocket tab (Issue 1382).&lt;br&gt;
-    Show string representation of binary payloads in WebSocket tab and message panels.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/websocket-release-16.zap</url>
-        <hash>SHA1:6cf3f4d5d7d12813f34e09339d90bf4353d16ed3</hash>
-        <date>2018-06-05</date>
-        <size>928242</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_websocket>
-	
+    </addon_accessControl>
     <addon>alertFilters</addon>
     <addon_alertFilters>
         <name>Context Alert Filters</name>
@@ -434,7 +60,6 @@
         <size>300077</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_alertFilters>
-
     <addon>alertReport</addon>
     <addon_alertReport>
         <name>Report alert generator</name>
@@ -452,505 +77,6 @@
         <size>9722880</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_alertReport>
-
-    <addon>ascanrulesBeta</addon>
-    <addon_ascanrulesBeta>
-        <name>Active scanner rules (beta)</name>
-        <description>The beta quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>23</version>
-        <file>ascanrulesBeta-beta-23.zap</file>
-        <status>beta</status>
-        <changes>At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrulesBeta-beta-23.zap</url>
-        <hash>SHA1:b3749aae5675fb48b01abc64687f52848d00bc0e</hash>
-        <date>2018-01-19</date>
-        <size>2774403</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_ascanrulesBeta>
-
-    <addon>beanshell</addon>
-    <addon_beanshell>
-        <name>BeanShell Console</name>
-        <description>Provides a BeanShell Console</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>beanshell-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/beanshell-beta-6.zap</url>
-        <hash>SHA1:9546aad4694ef047822bc17d3d9f532d3aa162b8</hash>
-        <date>2017-11-27</date>
-        <size>574028</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_beanshell>
-
-    <addon>bruteforce</addon>
-    <addon_bruteforce>
-        <name>Forced Browse</name>
-        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>bruteforce-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/bruteforce-beta-7.zap</url>
-        <hash>SHA1:4f28d919b7e8765a9acb3eaba5607d607f8b3710</hash>
-        <date>2017-11-27</date>
-        <size>1011548</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_bruteforce>
-
-    <addon>diff</addon>
-    <addon_diff>
-        <name>Diff</name>
-        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>diff-beta-8.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/diff-beta-8.zap</url>
-        <hash>SHA1:d76cfd841c5893faba628a1b45d27592cbeab291</hash>
-        <date>2017-11-27</date>
-        <size>241225</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_diff>
-
-    <addon>fuzz</addon>
-    <addon_fuzz>
-        <name>AdvFuzzer</name>
-        <description>Advanced fuzzer for manual testing</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <semver>2.0.1</semver>
-        <file>fuzz-beta-10.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzz-beta-10.zap</url>
-        <hash>SHA1:eb87f3fd76c7691b514b4977c81bcaa8cc3bae79</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
-        <date>2017-11-27</date>
-        <size>2418608</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_fuzz>
-
-    <addon>help_id_ID</addon>
-    <addon_help_id_ID>
-        <name>Help Indonesian</name>
-        <description>Indonesian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>2</version>
-        <file>help_id_ID-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_id_ID-beta-2.zap</url>
-        <hash>SHA1:7b7ba465a1eecac23781582a1f1d7dfbaef2d347</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>775452</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_id_ID>
-
-    <addon>help_ja_JP</addon>
-    <addon_help_ja_JP>
-        <name>Help - Japanese</name>
-        <description>Japanese version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>9</version>
-        <file>help_ja_JP-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_ja_JP-beta-9.zap</url>
-        <hash>SHA1:d91450eef7e4f3ce19fa9ad9f318fb80cc337ec1</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>774034</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_ja_JP>
-
-    <addon>help_zh_CN</addon>
-    <addon_help_zh_CN>
-        <name>Help Chinese Simplified</name>
-        <description>Chinese Simplified version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>2</version>
-        <file>help_zh_CN-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_zh_CN-beta-2.zap</url>
-        <hash>SHA1:bf58e29e3813b20df90e1691e81119e4a1a2e4f2</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>761680</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_zh_CN>
-
-    <addon>imagelocationscanner</addon>
-    <addon_imagelocationscanner>
-        <name>Image Location and Privacy Scanner</name>
-        <description>Image Location and Privacy Passive Scanner</description>
-        <author>Veggiespam and the ZAP Dev Team</author>
-        <version>1</version>
-        <file>imagelocationscanner-beta-1.zap</file>
-        <status>beta</status>
-        <changes>Promoted to beta and separated from the passive scan alpha add-on.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/imagelocationscanner-beta-1.zap</url>
-        <hash>SHA1:5fcd1183e055406b8dd725f434044ef73323f48f</hash>
-        <date>2018-02-27</date>
-        <size>607798</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_imagelocationscanner>
-
-    <addon>importurls</addon>
-    <addon_importurls>
-        <name>Import files containing URLs</name>
-        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>importurls-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/importurls-beta-5.zap</url>
-        <hash>SHA1:fc1386d20cf70a7aa42655303d22479009fa9a89</hash>
-        <date>2017-11-27</date>
-        <size>225043</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_importurls>
-
-    <addon>invoke</addon>
-    <addon_invoke>
-        <name>Invoke Applications</name>
-        <description>Invoke external applications passing context related information such as URLs and parameters</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>invoke-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Added additional parameter replacements of %msgid% and %header-*%&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/invoke-beta-9.zap</url>
-        <hash>SHA1:81df2e9d7794b273410c87336ef66cb4cc4dc6b6</hash>
-        <date>2018-02-19</date>
-        <size>314763</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_invoke>
-
-    <addon>jruby</addon>
-    <addon_jruby>
-        <name>Ruby scripting</name>
-        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>jruby-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jruby-beta-6.zap</url>
-        <hash>SHA1:99166f0e9f4337329ae8452da032986214f1eb73</hash>
-        <date>2017-11-27</date>
-        <size>22477473</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_jruby>
-
-    <addon>jsonview</addon>
-    <addon_jsonview>
-        <name>Json view</name>
-        <description>Adds a view that shows JSON messages nicely formatted</description>
-        <author>Juha Kivekäs</author>
-        <version>1</version>
-        <file>jsonview-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>Initial release</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jsonview-alpha-1.zap</url>
-        <hash>SHA1:be9a95e39722ff42af1160a195a56c9af9e285c1</hash>
-        <date>2018-02-08</date>
-        <size>10796</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_jsonview>
-
-    <addon>jython</addon>
-    <addon_jython>
-        <name>Python Scripting</name>
-        <description>Allows Python to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>jython-beta-10.zap</file>
-        <status>beta</status>
-        <changes>Correctly set path module defined in the options and address UI hang (Issue 4651).&lt;br&gt;
-    Minor tweak in extender template.&lt;br&gt;
-    Add default template for Script Input Vector.&lt;br&gt;
-    Add help page for the options.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jython-beta-10.zap</url>
-        <hash>SHA1:fedf4e6c30dfb52543d851bb668ab1c8101dd58f</hash>
-        <date>2018-05-08</date>
-        <size>41738465</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_jython>
-
-    <addon>plugnhack</addon>
-    <addon_plugnhack>
-        <name>Plug-n-Hack Configuration</name>
-        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
-        <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>plugnhack-beta-11.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/plugnhack-beta-11.zap</url>
-        <hash>SHA1:e3243495919a8d1a7f4bd69e60b7147690bb9836</hash>
-        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
-        <date>2017-11-27</date>
-        <size>722977</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_plugnhack>
-
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>portscan-beta-8.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/portscan-beta-8.zap</url>
-        <hash>SHA1:85b7377c65778d22a4c78fe1ff79b82245abc4c9</hash>
-        <date>2017-11-27</date>
-        <size>632994</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_portscan>
-
-    <addon>pscanrulesBeta</addon>
-    <addon_pscanrulesBeta>
-        <name>Passive scanner rules (beta)</name>
-        <description>The beta quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>18</version>
-        <file>pscanrulesBeta-beta-18.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes to address deprecation.&lt;br/&gt;
-    At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).&lt;br/&gt;
-        Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrulesBeta-beta-18.zap</url>
-        <hash>SHA1:caf60a429ff6c7c6f53fab09f94462a9c6e30150</hash>
-        <date>2018-01-19</date>
-        <size>559591</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_pscanrulesBeta>
-
-    <addon>replacer</addon>
-    <addon_replacer>
-        <name>Replacer</name>
-        <description>Easy way to replace strings in requests and responses.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>replacer-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Tweak help page.&lt;br&gt;
-    Ignore CFU HTTP messages.&lt;br&gt;
-    Allow to (explicitly) select Token Generator messages.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/replacer-beta-6.zap</url>
-        <hash>SHA1:94d43eee92dbbcf7854f64dd60c713c1a580e5ba</hash>
-        <date>2018-06-12</date>
-        <size>330710</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_replacer>
-
-    <addon>scripts</addon>
-    <addon_scripts>
-        <name>Script Console</name>
-        <description>Supports all JSR 223 scripting languages</description>
-        <author>ZAP Dev Team</author>
-        <version>24</version>
-        <file>scripts-beta-24.zap</file>
-        <status>beta</status>
-        <changes>Fix GUI freeze on script addition/removal through the API (Issue 4302).&lt;br&gt;
-    Prompt for a charset when failed to read the script file (Issue 3383).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/scripts-beta-24.zap</url>
-        <hash>SHA1:63295325786e27ee0d5920bb46656eda7ea1f514</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
-        <date>2018-01-25</date>
-        <size>639756</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_scripts>
-
-    <addon>sqliplugin</addon>
-    <addon_sqliplugin>
-        <name>Advanced SQLInjection Scanner</name>
-        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
-        <author>Andrea Pompili (Yhawke)</author>
-        <version>12</version>
-        <file>sqliplugin-beta-12.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/sqliplugin-beta-12.zap</url>
-        <hash>SHA1:7661c839f8ab0fa731d6629de1b7526b706d6bb6</hash>
-        <date>2017-11-27</date>
-        <size>119265</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_sqliplugin>
-
-    <addon>svndigger</addon>
-    <addon_svndigger>
-        <name>SVN Digger files</name>
-        <description>SVN Digger files which can be used with ZAP forced browsing</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>svndigger-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/svndigger-beta-3.zap</url>
-        <hash>SHA1:8c7187180ed48466d6829e39469cc3d0915b1cbf</hash>
-        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
-        <date>2017-11-27</date>
-        <size>615459</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_svndigger>
-
-    <addon>tips</addon>
-    <addon_tips>
-        <name>Tips and Tricks</name>
-        <description>Display ZAP Tips and Tricks</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>tips-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tips-beta-6.zap</url>
-        <hash>SHA1:b6a560a292fa21b867a5c2385bfab0afcdfe0cd5</hash>
-        <date>2017-11-27</date>
-        <size>517219</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_tips>
-
-    <addon>tokengen</addon>
-    <addon_tokengen>
-        <name>Token generation and analysis</name>
-        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
-        <author>ZAP Dev Team</author>
-        <version>12</version>
-        <file>tokengen-beta-12.zap</file>
-        <status>beta</status>
-        <changes>Stop the test and clear the panel on session changes.&lt;br&gt;
-    Respect the current mode and react to changes.&lt;br&gt;
-    Inform of running test (e.g. on session change, add-on uninstall).&lt;br&gt;
-    Allow to configure the number of threads.&lt;br&gt;
-    Allow to delay the requests.&lt;br&gt;
-    Update minimum ZAP version to 2.6.0.&lt;br&gt;
-    Deletes the cookie in question before sending the request.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tokengen-beta-12.zap</url>
-        <hash>SHA1:71bb8a5bc15fe725b5ba38939559696589782583</hash>
-        <date>2018-05-17</date>
-        <size>323564</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_tokengen>
-
-    <addon>treetools</addon>
-    <addon_treetools>
-        <name>TreeTools</name>
-        <description>Tools to add functionality to the tree view.</description>
-        <author>Carl Sampson</author>
-        <version>7</version>
-        <file>treetools-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602)</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/treetools-beta-7.zap</url>
-        <hash>SHA1:38fbc4d4e22c0da73a4048522d250fa4ac89bdab</hash>
-        <date>2017-11-27</date>
-        <size>18821</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_treetools>
-
-    <addon>webdriverlinux</addon>
-    <addon_webdriverlinux>
-        <name>Linux WebDrivers</name>
-        <description>Linux WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdriverlinux-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverlinux-beta-6.zap</url>
-        <hash>SHA1:ff062a3bc9869880d41f3e20587a388a403a8af9</hash>
-        <date>2018-06-11</date>
-        <size>9249857</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdriverlinux>
-    <addon>webdrivermacos</addon>
-
-    <addon_webdrivermacos>
-        <name>MacOS WebDrivers</name>
-        <description>MacOS WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdrivermacos-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdrivermacos-beta-6.zap</url>
-        <hash>SHA1:ce59ca4b71b776c3a9d8825a65fe613edf45f897</hash>
-        <date>2018-06-11</date>
-        <size>7228885</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdrivermacos>
-
-    <addon>webdriverwindows</addon>
-    <addon_webdriverwindows>
-        <name>Windows WebDrivers</name>
-        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdriverwindows-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverwindows-beta-6.zap</url>
-        <hash>SHA1:7fa7c1dbb6812031c52c85e8de4767671921e2e0</hash>
-        <date>2018-06-11</date>
-        <size>10943223</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdriverwindows>
-
-    <addon>zest</addon>
-    <addon_zest>
-        <name>Zest - Graphical Security Scripting Language</name>
-        <description>A graphical security scripting language, ZAPs macro language on steroids</description>
-        <author>ZAP Dev Team</author>
-        <version>27</version>
-        <file>zest-beta-27.zap</file>
-        <status>beta</status>
-        <changes>Fix exception when editing Action - Script with unsaved scripts.&lt;br&gt;
-    Allow to select more HTTP methods in Zest Request dialogue.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/zest-beta-27.zap</url>
-        <hash>SHA1:aa66b3e03f924265f011044747b54de967cecde4</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</info>
-        <date>2018-01-19</date>
-        <size>2106780</size>
-        <not-before-version>2.7.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>&gt;=2.0.0 &amp; &lt;3.0.0</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_zest>
-
-    <addon>accessControl</addon>
-    <addon_accessControl>
-        <name>Access Control Testing</name>
-        <description>Adds a set of tools for testing access control in web applications.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>accessControl-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/accessControl-alpha-4.zap</url>
-        <hash>SHA1:c5e590e41dfeec29026956a1e08c0f8b024c0dc4</hash>
-        <date>2017-11-28</date>
-        <size>513559</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_accessControl>
-
     <addon>amf</addon>
     <addon_amf>
         <name>AMF</name>
@@ -966,7 +92,23 @@
         <size>813490</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_amf>
-
+    <addon>ascanrules</addon>
+    <addon_ascanrules>
+        <name>Active scanner rules</name>
+        <description>The release quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>31</version>
+        <file>ascanrules-release-31.zap</file>
+        <status>release</status>
+        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
+    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
+    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
+        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
+        <date>2018-03-05</date>
+        <size>635944</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_ascanrules>
     <addon>ascanrulesAlpha</addon>
     <addon_ascanrulesAlpha>
         <name>Active scanner rules (alpha)</name>
@@ -986,7 +128,36 @@
         <size>1594615</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_ascanrulesAlpha>
-
+    <addon>ascanrulesBeta</addon>
+    <addon_ascanrulesBeta>
+        <name>Active scanner rules (beta)</name>
+        <description>The beta quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>23</version>
+        <file>ascanrulesBeta-beta-23.zap</file>
+        <status>beta</status>
+        <changes>At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrulesBeta-beta-23.zap</url>
+        <hash>SHA1:b3749aae5675fb48b01abc64687f52848d00bc0e</hash>
+        <date>2018-01-19</date>
+        <size>2774403</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_ascanrulesBeta>
+    <addon>attacksurfacedetector</addon>
+    <addon_attacksurfacedetector>
+        <name>Attack Surface Detector</name>
+        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
+        <author>Secure Decisions (Matthew DeLetto)</author>
+        <version>1.1.1</version>
+        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
+        <status>alpha</status>
+        <changes>First Version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
+        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
+        <date>2018-06-28</date>
+        <size>14387774</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_attacksurfacedetector>
     <addon>authstats</addon>
     <addon_authstats>
         <name>Authentication Statistics</name>
@@ -1003,7 +174,21 @@
         <size>238686</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_authstats>
-
+    <addon>beanshell</addon>
+    <addon_beanshell>
+        <name>BeanShell Console</name>
+        <description>Provides a BeanShell Console</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>beanshell-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/beanshell-beta-6.zap</url>
+        <hash>SHA1:9546aad4694ef047822bc17d3d9f532d3aa162b8</hash>
+        <date>2017-11-27</date>
+        <size>574028</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_beanshell>
     <addon>browserView</addon>
     <addon_browserView>
         <name>Browser View</name>
@@ -1019,7 +204,22 @@
         <size>193880</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_browserView>
-
+    <addon>bruteforce</addon>
+    <addon_bruteforce>
+        <name>Forced Browse</name>
+        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>bruteforce-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/bruteforce-beta-7.zap</url>
+        <hash>SHA1:4f28d919b7e8765a9acb3eaba5607d607f8b3710</hash>
+        <date>2017-11-27</date>
+        <size>1011548</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_bruteforce>
     <addon>bugtracker</addon>
     <addon_bugtracker>
         <name>Bug Tracker</name>
@@ -1035,7 +235,6 @@
         <size>2002624</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_bugtracker>
-
     <addon>callgraph</addon>
     <addon_callgraph>
         <name>Call Graph</name>
@@ -1051,7 +250,6 @@
         <size>1160586</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_callgraph>
-
     <addon>cmss</addon>
     <addon_cmss>
         <name>WAFP Extension</name>
@@ -1068,7 +266,6 @@
         <size>545349</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_cmss>
-
     <addon>codedx</addon>
     <addon_codedx>
         <name>Code Dx Extension</name>
@@ -1086,7 +283,6 @@
         <size>1415674</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_codedx>
-
     <addon>communityScripts</addon>
     <addon_communityScripts>
         <name>Community Scripts</name>
@@ -1103,7 +299,23 @@
         <size>387552</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_communityScripts>
-
+    <addon>coreLang</addon>
+    <addon_coreLang>
+        <name>Core Language Files</name>
+        <description>Translations of the core language files</description>
+        <author>ZAP Dev Team</author>
+        <version>13</version>
+        <file>coreLang-release-13.zap</file>
+        <status>release</status>
+        <changes>Added help file with credits.&lt;br&gt;
+	Updated the languages files from Crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/coreLang-release-13.zap</url>
+        <hash>SHA1:8074521b78c3fc9d63e0543ca3887afa2424167e</hash>
+        <info>https://crowdin.com/project/owasp-zap</info>
+        <date>2018-01-15</date>
+        <size>3221988</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_coreLang>
     <addon>cspscanner</addon>
     <addon_cspscanner>
         <name>Content Security Policy Scanner</name>
@@ -1121,7 +333,6 @@
         <size>176663</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_cspscanner>
-
     <addon>customreport</addon>
     <addon_customreport>
         <name>CustomReport</name>
@@ -1138,7 +349,71 @@
         <size>575782</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_customreport>
-
+    <addon>diff</addon>
+    <addon_diff>
+        <name>Diff</name>
+        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>diff-beta-8.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/diff-beta-8.zap</url>
+        <hash>SHA1:d76cfd841c5893faba628a1b45d27592cbeab291</hash>
+        <date>2017-11-27</date>
+        <size>241225</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_diff>
+    <addon>directorylistv1</addon>
+    <addon_directorylistv1>
+        <name>Directory List v1.0</name>
+        <description>List of directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv1-release-3.zap</file>
+        <status>release</status>
+        <changes>Removed repeated files.&lt;br&gt;
+	Added strings for version control directories of Git, Mercurial, SVN, CVS, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv1-release-3.zap</url>
+        <hash>SHA1:b1697b64f5bc50f6bfcb4047b37789850cc3e252</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>847619</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv1>
+    <addon>directorylistv2_3</addon>
+    <addon_directorylistv2_3>
+        <name>Directory List v2.3</name>
+        <description>Lists of directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv2_3-release-3.zap</file>
+        <status>release</status>
+        <changes>Removed repeated files.&lt;br&gt;
+	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3-release-3.zap</url>
+        <hash>SHA1:e3b9cb6a9bae87a0dbcf73ff52f7b4406486d5c0</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>8608734</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv2_3>
+    <addon>directorylistv2_3_lc</addon>
+    <addon_directorylistv2_3_lc>
+        <name>Directory List v2.3 LC</name>
+        <description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv2_3_lc-release-3.zap</file>
+        <status>release</status>
+        <changes>Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3_lc-release-3.zap</url>
+        <hash>SHA1:03a5ec11530203be6625633821ab3c05754b2daa</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>7454767</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv2_3_lc>
     <addon>domxss</addon>
     <addon_domxss>
         <name>DOM XSS Active scanner rule</name>
@@ -1162,7 +437,6 @@
             </addons>
         </dependencies>
     </addon_domxss>
-
     <addon>exportreport</addon>
     <addon_exportreport>
         <name>Export Report</name>
@@ -1178,7 +452,6 @@
         <size>6402380</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_exportreport>
-
     <addon>formhandler</addon>
     <addon_formhandler>
         <name>Form Handler</name>
@@ -1194,7 +467,86 @@
         <size>2121043</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_formhandler>
-
+    <addon>fuzz</addon>
+    <addon_fuzz>
+        <name>AdvFuzzer</name>
+        <description>Advanced fuzzer for manual testing</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <semver>2.0.1</semver>
+        <file>fuzz-beta-10.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzz-beta-10.zap</url>
+        <hash>SHA1:eb87f3fd76c7691b514b4977c81bcaa8cc3bae79</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
+        <date>2017-11-27</date>
+        <size>2418608</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_fuzz>
+    <addon>fuzzdb</addon>
+    <addon_fuzzdb>
+        <name>FuzzDB files</name>
+        <description>FuzzDB files which can be used with the ZAP fuzzer</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>fuzzdb-release-4.zap</file>
+        <status>release</status>
+        <changes>Update FuzzDB files.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzzdb-release-4.zap</url>
+        <hash>SHA1:6da7ce962bae6b54954415eb71059467e93f14f6</hash>
+        <info>https://github.com/fuzzdb-project/fuzzdb/</info>
+        <date>2017-11-27</date>
+        <size>5627107</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_fuzzdb>
+    <addon>gettingStarted</addon>
+    <addon_gettingStarted>
+        <name>Getting Started with ZAP Guide</name>
+        <description>A short Getting Started with ZAP Guide</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>gettingStarted-release-9.zap</file>
+        <status>release</status>
+        <changes>Added the Spanish, Filipino and Indonesian translations</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/gettingStarted-release-9.zap</url>
+        <hash>SHA1:85108d1ae8df5baae37e62a8494d774a32268782</hash>
+        <date>2018-02-13</date>
+        <size>1623605</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_gettingStarted>
+    <addon>groovy</addon>
+    <addon_groovy>
+        <name>Groovy Scripting</name>
+        <description>Allows Groovy to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>groovy-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Add help.&lt;br&gt;
+    Added script templates.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/groovy-alpha-2.zap</url>
+        <hash>SHA1:7f0d54eaf987a435e941a422378c124f3fd29259</hash>
+        <date>2018-04-19</date>
+        <size>7334399</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_groovy>
+    <addon>help</addon>
+    <addon_help>
+        <name>Help - English</name>
+        <description>English (master) version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>8</version>
+        <file>help-release-8.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help-release-8.zap</url>
+        <hash>SHA1:137c6627366d86e4629d32aa066e0ebf457ebfe3</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpIntro</info>
+        <date>2017-11-27</date>
+        <size>725234</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help>
     <addon>help_bs_BA</addon>
     <addon_help_bs_BA>
         <name>Help - Bosnian</name>
@@ -1211,24 +563,22 @@
         <size>747536</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_help_bs_BA>
-    
-    <addon>help_fr_FR</addon>
-    <addon_help_fr_FR>
-        <name>Help - French</name>
-        <description>French version of the ZAP help file.</description>
+    <addon>help_es_ES</addon>
+    <addon_help_es_ES>
+        <name>Help - Spanish</name>
+        <description>Spanish version of the ZAP help file.</description>
         <author>ZAP Crowdin Team</author>
         <version>9</version>
-        <file>help_fr_FR-alpha-9.zap</file>
-        <status>alpha</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_fr_FR-alpha-9.zap</url>
-        <hash>SHA1:05aa37ec86966990fa33190c65a53d1c5a6dc955</hash>
+        <file>help_es_ES-release-9.zap</file>
+        <status>release</status>
+        <changes>Updated with the latest files from crowdin, promoted to release</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_es_ES-release-9.zap</url>
+        <hash>SHA1:c17a1d63de54a99feb5344ea3f07e66dcbd7d4d1</hash>
         <info>https://crowdin.com/project/owasp-zap-help</info>
         <date>2018-02-08</date>
-        <size>752466</size>
+        <size>810573</size>
         <not-before-version>2.7.0</not-before-version>
-    </addon_help_fr_FR>
-
+    </addon_help_es_ES>
     <addon>help_fil_PH</addon>
     <addon_help_fil_PH>
         <name>Help Filipino</name>
@@ -1245,7 +595,102 @@
         <size>818996</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_help_fil_PH>
-
+    <addon>help_fr_FR</addon>
+    <addon_help_fr_FR>
+        <name>Help - French</name>
+        <description>French version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>9</version>
+        <file>help_fr_FR-alpha-9.zap</file>
+        <status>alpha</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_fr_FR-alpha-9.zap</url>
+        <hash>SHA1:05aa37ec86966990fa33190c65a53d1c5a6dc955</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>752466</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_fr_FR>
+    <addon>help_id_ID</addon>
+    <addon_help_id_ID>
+        <name>Help Indonesian</name>
+        <description>Indonesian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>2</version>
+        <file>help_id_ID-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_id_ID-beta-2.zap</url>
+        <hash>SHA1:7b7ba465a1eecac23781582a1f1d7dfbaef2d347</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>775452</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_id_ID>
+    <addon>help_ja_JP</addon>
+    <addon_help_ja_JP>
+        <name>Help - Japanese</name>
+        <description>Japanese version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>9</version>
+        <file>help_ja_JP-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_ja_JP-beta-9.zap</url>
+        <hash>SHA1:d91450eef7e4f3ce19fa9ad9f318fb80cc337ec1</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>774034</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_ja_JP>
+    <addon>help_pt_BR</addon>
+    <addon_help_pt_BR>
+        <name>Help - Portuguese, Brazilian</name>
+        <description>Portuguese, Brazilian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>10</version>
+        <file>help_pt_BR-release-10.zap</file>
+        <status>release</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_pt_BR-release-10.zap</url>
+        <hash>SHA1:43ef048b4faff32e6ed59dfbd07174ceec71bbdb</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>793044</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_pt_BR>
+    <addon>help_tr_TR</addon>
+    <addon_help_tr_TR>
+        <name>Help - Turkish</name>
+        <description>Turkish version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>1</version>
+        <file>help_tr_TR-release-1.zap</file>
+        <status>release</status>
+        <changes>First version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_tr_TR-release-1.zap</url>
+        <hash>SHA1:2d4c3c115e0f401c37049dd1802f413b42f88e5e</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>815439</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_tr_TR>
+    <addon>help_zh_CN</addon>
+    <addon_help_zh_CN>
+        <name>Help Chinese Simplified</name>
+        <description>Chinese Simplified version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>2</version>
+        <file>help_zh_CN-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_zh_CN-beta-2.zap</url>
+        <hash>SHA1:bf58e29e3813b20df90e1691e81119e4a1a2e4f2</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>761680</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_zh_CN>
     <addon>highlighter</addon>
     <addon_highlighter>
         <name>Highlighter</name>
@@ -1263,7 +708,6 @@
         <size>9210</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_highlighter>
-
     <addon>httpsInfo</addon>
     <addon_httpsInfo>
         <name>HttpsInfo</name>
@@ -1279,7 +723,21 @@
         <size>5542543</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_httpsInfo>
-
+    <addon>imagelocationscanner</addon>
+    <addon_imagelocationscanner>
+        <name>Image Location and Privacy Scanner</name>
+        <description>Image Location and Privacy Passive Scanner</description>
+        <author>Veggiespam and the ZAP Dev Team</author>
+        <version>1</version>
+        <file>imagelocationscanner-beta-1.zap</file>
+        <status>beta</status>
+        <changes>Promoted to beta and separated from the passive scan alpha add-on.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/imagelocationscanner-beta-1.zap</url>
+        <hash>SHA1:5fcd1183e055406b8dd725f434044ef73323f48f</hash>
+        <date>2018-02-27</date>
+        <size>607798</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_imagelocationscanner>
     <addon>importLogFiles</addon>
     <addon_importLogFiles>
         <name>Log File Importer</name>
@@ -1296,7 +754,66 @@
         <size>152736</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_importLogFiles>
-
+    <addon>importurls</addon>
+    <addon_importurls>
+        <name>Import files containing URLs</name>
+        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>importurls-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/importurls-beta-5.zap</url>
+        <hash>SHA1:fc1386d20cf70a7aa42655303d22479009fa9a89</hash>
+        <date>2017-11-27</date>
+        <size>225043</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_importurls>
+    <addon>invoke</addon>
+    <addon_invoke>
+        <name>Invoke Applications</name>
+        <description>Invoke external applications passing context related information such as URLs and parameters</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>invoke-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Added additional parameter replacements of %msgid% and %header-*%&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/invoke-beta-9.zap</url>
+        <hash>SHA1:81df2e9d7794b273410c87336ef66cb4cc4dc6b6</hash>
+        <date>2018-02-19</date>
+        <size>314763</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_invoke>
+    <addon>jruby</addon>
+    <addon_jruby>
+        <name>Ruby scripting</name>
+        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>jruby-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jruby-beta-6.zap</url>
+        <hash>SHA1:99166f0e9f4337329ae8452da032986214f1eb73</hash>
+        <date>2017-11-27</date>
+        <size>22477473</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_jruby>
+    <addon>jsonview</addon>
+    <addon_jsonview>
+        <name>Json view</name>
+        <description>Adds a view that shows JSON messages nicely formatted</description>
+        <author>Juha Kivekäs</author>
+        <version>1</version>
+        <file>jsonview-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>Initial release</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jsonview-alpha-1.zap</url>
+        <hash>SHA1:be9a95e39722ff42af1160a195a56c9af9e285c1</hash>
+        <date>2018-02-08</date>
+        <size>10796</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_jsonview>
     <addon>jxbrowser</addon>
     <addon_jxbrowser>
         <name>JxBrowser (core)</name>
@@ -1313,7 +830,6 @@
         <size>1481399</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_jxbrowser>
-
     <addon>jxbrowserlinux64</addon>
     <addon_jxbrowserlinux64>
         <name>JxBrowser (Linux 64)</name>
@@ -1339,7 +855,6 @@
             </addons>
         </dependencies>
     </addon_jxbrowserlinux64>
-
     <addon>jxbrowsermacos</addon>
     <addon_jxbrowsermacos>
         <name>JxBrowser (Mac OS)</name>
@@ -1365,7 +880,6 @@
             </addons>
         </dependencies>
     </addon_jxbrowsermacos>
-
     <addon>jxbrowserwindows</addon>
     <addon_jxbrowserwindows>
         <name>JxBrowser (Windows)</name>
@@ -1391,7 +905,40 @@
             </addons>
         </dependencies>
     </addon_jxbrowserwindows>
-
+    <addon>jython</addon>
+    <addon_jython>
+        <name>Python Scripting</name>
+        <description>Allows Python to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>jython-beta-10.zap</file>
+        <status>beta</status>
+        <changes>Correctly set path module defined in the options and address UI hang (Issue 4651).&lt;br&gt;
+    Minor tweak in extender template.&lt;br&gt;
+    Add default template for Script Input Vector.&lt;br&gt;
+    Add help page for the options.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jython-beta-10.zap</url>
+        <hash>SHA1:fedf4e6c30dfb52543d851bb668ab1c8101dd58f</hash>
+        <date>2018-05-08</date>
+        <size>41738465</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_jython>
+    <addon>onlineMenu</addon>
+    <addon_onlineMenu>
+        <name>Online menus</name>
+        <description>ZAP Online menu items</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>onlineMenu-release-6.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/onlineMenu-release-6.zap</url>
+        <hash>SHA1:343c6f9891b311739770bbb3e25d12c766bd1866</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</info>
+        <date>2017-11-27</date>
+        <size>206306</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_onlineMenu>
     <addon>openapi</addon>
     <addon_openapi>
         <name>OpenAPI Support</name>
@@ -1407,7 +954,53 @@
         <size>3324050</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_openapi>
-
+    <addon>plugnhack</addon>
+    <addon_plugnhack>
+        <name>Plug-n-Hack Configuration</name>
+        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
+        <author>ZAP Dev Team</author>
+        <version>11</version>
+        <file>plugnhack-beta-11.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/plugnhack-beta-11.zap</url>
+        <hash>SHA1:e3243495919a8d1a7f4bd69e60b7147690bb9836</hash>
+        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
+        <date>2017-11-27</date>
+        <size>722977</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_plugnhack>
+    <addon>portscan</addon>
+    <addon_portscan>
+        <name>Port Scanner</name>
+        <description>Allows to port scan a target server</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>portscan-beta-8.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/portscan-beta-8.zap</url>
+        <hash>SHA1:85b7377c65778d22a4c78fe1ff79b82245abc4c9</hash>
+        <date>2017-11-27</date>
+        <size>632994</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_portscan>
+    <addon>pscanrules</addon>
+    <addon_pscanrules>
+        <name>Passive scanner rules</name>
+        <description>The release quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>22</version>
+        <file>pscanrules-release-22.zap</file>
+        <status>release</status>
+        <changes>Retired the password auto-complete passive scan rule (Issue 4215).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrules-release-22.zap</url>
+        <hash>SHA1:3a3203bcbca8b9091baf12bb5ddf4ec192a15295</hash>
+        <date>2018-01-19</date>
+        <size>518316</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_pscanrules>
     <addon>pscanrulesAlpha</addon>
     <addon_pscanrulesAlpha>
         <name>Passive scanner rules (alpha)</name>
@@ -1424,7 +1017,57 @@
         <size>1747326</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_pscanrulesAlpha>
-
+    <addon>pscanrulesBeta</addon>
+    <addon_pscanrulesBeta>
+        <name>Passive scanner rules (beta)</name>
+        <description>The beta quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>18</version>
+        <file>pscanrulesBeta-beta-18.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes to address deprecation.&lt;br/&gt;
+    At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).&lt;br/&gt;
+        Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrulesBeta-beta-18.zap</url>
+        <hash>SHA1:caf60a429ff6c7c6f53fab09f94462a9c6e30150</hash>
+        <date>2018-01-19</date>
+        <size>559591</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_pscanrulesBeta>
+    <addon>quickstart</addon>
+    <addon_quickstart>
+        <name>Quick Start</name>
+        <description>Provides a tab which allows you to quickly test a target application</description>
+        <author>ZAP Dev Team</author>
+        <version>23</version>
+        <file>quickstart-release-23.zap</file>
+        <status>release</status>
+        <changes>Update for 2.7.0.&lt;br&gt;
+    Stop the quick scan if the session is changed.&lt;br&gt;
+    Added toolbar button to launch the latest browser chosen.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/quickstart-release-23.zap</url>
+        <hash>SHA1:34aed4c9a93220978799aff7002236a669c02b25</hash>
+        <date>2018-01-19</date>
+        <size>436181</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_quickstart>
+    <addon>replacer</addon>
+    <addon_replacer>
+        <name>Replacer</name>
+        <description>Easy way to replace strings in requests and responses.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>replacer-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Tweak help page.&lt;br&gt;
+    Ignore CFU HTTP messages.&lt;br&gt;
+    Allow to (explicitly) select Token Generator messages.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/replacer-beta-6.zap</url>
+        <hash>SHA1:94d43eee92dbbcf7854f64dd60c713c1a580e5ba</hash>
+        <date>2018-06-12</date>
+        <size>330710</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_replacer>
     <addon>requester</addon>
     <addon_requester>
         <name>Requester</name>
@@ -1440,7 +1083,21 @@
         <size>55741</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_requester>
-
+    <addon>reveal</addon>
+    <addon_reveal>
+        <name>Reveal</name>
+        <description>Show hidden fields and enable disabled fields</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>reveal-release-2.zap</file>
+        <status>release</status>
+        <changes>Code changes and API documentation.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/reveal-release-2.zap</url>
+        <hash>SHA1:caec390697cdc2c82945371e80901af05cc2bfbc</hash>
+        <date>2017-11-27</date>
+        <size>230262</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_reveal>
     <addon>revisit</addon>
     <addon_revisit>
         <name>Revisit</name>
@@ -1457,7 +1114,6 @@
         <size>289297</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_revisit>
-
     <addon>saml</addon>
     <addon_saml>
         <name>SAML Extension</name>
@@ -1474,7 +1130,69 @@
         <size>997659</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_saml>
-
+    <addon>saverawmessage</addon>
+    <addon_saverawmessage>
+        <name>Save Raw Message</name>
+        <description>Allows to save content of HTTP messages as binary</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>saverawmessage-release-4.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/saverawmessage-release-4.zap</url>
+        <hash>SHA1:df600792159042a452e3e9215d9b89b21417bf88</hash>
+        <date>2017-11-27</date>
+        <size>27756</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_saverawmessage>
+    <addon>savexmlmessage</addon>
+    <addon_savexmlmessage>
+        <name>Save XML Message</name>
+        <description>Allows to save content of HTTP messages as XML</description>
+        <author>thatsn0tmysite</author>
+        <version>0.0.1</version>
+        <file>savexmlmessage-alpha-0.0.1.zap</file>
+        <status>alpha</status>
+        <changes>Initial release.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/savexmlmessage-alpha-0.0.1.zap</url>
+        <hash>SHA1:5a819610819e4edc227df5da4dac3c886f2b2d29</hash>
+        <date>2018-05-30</date>
+        <size>12873</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_savexmlmessage>
+    <addon>scripts</addon>
+    <addon_scripts>
+        <name>Script Console</name>
+        <description>Supports all JSR 223 scripting languages</description>
+        <author>ZAP Dev Team</author>
+        <version>24</version>
+        <file>scripts-beta-24.zap</file>
+        <status>beta</status>
+        <changes>Fix GUI freeze on script addition/removal through the API (Issue 4302).&lt;br&gt;
+    Prompt for a charset when failed to read the script file (Issue 3383).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/scripts-beta-24.zap</url>
+        <hash>SHA1:63295325786e27ee0d5920bb46656eda7ea1f514</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
+        <date>2018-01-25</date>
+        <size>639756</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_scripts>
+    <addon>selenium</addon>
+    <addon_selenium>
+        <name>Selenium</name>
+        <description>WebDriver provider and includes HtmlUnit browser</description>
+        <author>ZAP Dev Team</author>
+        <version>13</version>
+        <semver>2.0.0</semver>
+        <file>selenium-release-13.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/selenium-release-13.zap</url>
+        <hash>SHA1:27805e3b31a189d0377d359d0c9551dc820adde0</hash>
+        <date>2017-11-27</date>
+        <size>22796677</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_selenium>
     <addon>sequence</addon>
     <addon_sequence>
         <name>Sequence</name>
@@ -1497,7 +1215,6 @@
             </addons>
         </dependencies>
     </addon_sequence>
-
     <addon>soap</addon>
     <addon_soap>
         <name>SOAP Scanner</name>
@@ -1513,7 +1230,45 @@
         <size>7471507</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_soap>
-
+    <addon>spiderAjax</addon>
+    <addon_spiderAjax>
+        <name>Ajax Spider</name>
+        <description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
+        <author>ZAP Dev Team</author>
+        <version>21</version>
+        <file>spiderAjax-release-21.zap</file>
+        <status>release</status>
+        <changes>Reset API scan also when in daemon mode (Issue 4163).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/spiderAjax-release-21.zap</url>
+        <hash>SHA1:92f5a3ecded1d5e0f3b889b07656f5ec8414ada0</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</info>
+        <date>2018-01-19</date>
+        <size>2597145</size>
+        <not-before-version>2.7.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>2.*</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_spiderAjax>
+    <addon>sqliplugin</addon>
+    <addon_sqliplugin>
+        <name>Advanced SQLInjection Scanner</name>
+        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
+        <author>Andrea Pompili (Yhawke)</author>
+        <version>12</version>
+        <file>sqliplugin-beta-12.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/sqliplugin-beta-12.zap</url>
+        <hash>SHA1:7661c839f8ab0fa731d6629de1b7526b706d6bb6</hash>
+        <date>2017-11-27</date>
+        <size>119265</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_sqliplugin>
     <addon>sse</addon>
     <addon_sse>
         <name>Server-Sent Events</name>
@@ -1528,7 +1283,37 @@
         <size>333669</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_sse>
-
+    <addon>svndigger</addon>
+    <addon_svndigger>
+        <name>SVN Digger files</name>
+        <description>SVN Digger files which can be used with ZAP forced browsing</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>svndigger-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/svndigger-beta-3.zap</url>
+        <hash>SHA1:8c7187180ed48466d6829e39469cc3d0915b1cbf</hash>
+        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
+        <date>2017-11-27</date>
+        <size>615459</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_svndigger>
+    <addon>tips</addon>
+    <addon_tips>
+        <name>Tips and Tricks</name>
+        <description>Display ZAP Tips and Tricks</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>tips-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tips-beta-6.zap</url>
+        <hash>SHA1:b6a560a292fa21b867a5c2385bfab0afcdfe0cd5</hash>
+        <date>2017-11-27</date>
+        <size>517219</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_tips>
     <addon>tlsdebug</addon>
     <addon_tlsdebug>
         <name>TLS Debug</name>
@@ -1544,7 +1329,42 @@
         <size>234482</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_tlsdebug>
-
+    <addon>tokengen</addon>
+    <addon_tokengen>
+        <name>Token generation and analysis</name>
+        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
+        <author>ZAP Dev Team</author>
+        <version>12</version>
+        <file>tokengen-beta-12.zap</file>
+        <status>beta</status>
+        <changes>Stop the test and clear the panel on session changes.&lt;br&gt;
+    Respect the current mode and react to changes.&lt;br&gt;
+    Inform of running test (e.g. on session change, add-on uninstall).&lt;br&gt;
+    Allow to configure the number of threads.&lt;br&gt;
+    Allow to delay the requests.&lt;br&gt;
+    Update minimum ZAP version to 2.6.0.&lt;br&gt;
+    Deletes the cookie in question before sending the request.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tokengen-beta-12.zap</url>
+        <hash>SHA1:71bb8a5bc15fe725b5ba38939559696589782583</hash>
+        <date>2018-05-17</date>
+        <size>323564</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_tokengen>
+    <addon>treetools</addon>
+    <addon_treetools>
+        <name>TreeTools</name>
+        <description>Tools to add functionality to the tree view.</description>
+        <author>Carl Sampson</author>
+        <version>7</version>
+        <file>treetools-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602)</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/treetools-beta-7.zap</url>
+        <hash>SHA1:38fbc4d4e22c0da73a4048522d250fa4ac89bdab</hash>
+        <date>2017-11-27</date>
+        <size>18821</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_treetools>
     <addon>viewstate</addon>
     <addon_viewstate>
         <name>ViewState</name>
@@ -1559,7 +1379,6 @@
         <size>43907</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_viewstate>
-
     <addon>vulncheck</addon>
     <addon_vulncheck>
         <name>VulnCheck Extension</name>
@@ -1575,7 +1394,6 @@
         <size>35553</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_vulncheck>
-
     <addon>wappalyzer</addon>
     <addon_wappalyzer>
         <name>Wappalyzer - Technology Detection</name>
@@ -1592,5 +1410,96 @@
         <size>1655510</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_wappalyzer>
-
+    <addon>webdriverlinux</addon>
+    <addon_webdriverlinux>
+        <name>Linux WebDrivers</name>
+        <description>Linux WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdriverlinux-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverlinux-beta-6.zap</url>
+        <hash>SHA1:ff062a3bc9869880d41f3e20587a388a403a8af9</hash>
+        <date>2018-06-11</date>
+        <size>9249857</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdriverlinux>
+    <addon>webdrivermacos</addon>
+    <addon_webdrivermacos>
+        <name>MacOS WebDrivers</name>
+        <description>MacOS WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdrivermacos-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdrivermacos-beta-6.zap</url>
+        <hash>SHA1:ce59ca4b71b776c3a9d8825a65fe613edf45f897</hash>
+        <date>2018-06-11</date>
+        <size>7228885</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdrivermacos>
+    <addon>webdriverwindows</addon>
+    <addon_webdriverwindows>
+        <name>Windows WebDrivers</name>
+        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdriverwindows-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverwindows-beta-6.zap</url>
+        <hash>SHA1:7fa7c1dbb6812031c52c85e8de4767671921e2e0</hash>
+        <date>2018-06-11</date>
+        <size>10943223</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdriverwindows>
+    <addon>websocket</addon>
+    <addon_websocket>
+        <name>WebSockets</name>
+        <description>Allows you to inspect WebSocket communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>16</version>
+        <file>websocket-release-16.zap</file>
+        <status>release</status>
+        <changes>Tweak About help page.&lt;br&gt;
+    Remove event consumers when the channel is closed.&lt;br&gt;
+    Don't enable the sender scripts by default.&lt;br&gt;
+    Fix send of CLOSE messages with message editor (Issue 4657).&lt;br&gt;
+    Add missing error message.&lt;br&gt;
+    Fix removal of pop up menu items.&lt;br&gt;
+    Allow to filter by payload in WebSocket tab (Issue 1382).&lt;br&gt;
+    Show string representation of binary payloads in WebSocket tab and message panels.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/websocket-release-16.zap</url>
+        <hash>SHA1:6cf3f4d5d7d12813f34e09339d90bf4353d16ed3</hash>
+        <date>2018-06-05</date>
+        <size>928242</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_websocket>
+    <addon>zest</addon>
+    <addon_zest>
+        <name>Zest - Graphical Security Scripting Language</name>
+        <description>A graphical security scripting language, ZAPs macro language on steroids</description>
+        <author>ZAP Dev Team</author>
+        <version>27</version>
+        <file>zest-beta-27.zap</file>
+        <status>beta</status>
+        <changes>Fix exception when editing Action - Script with unsaved scripts.&lt;br&gt;
+    Allow to select more HTTP methods in Zest Request dialogue.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/zest-beta-27.zap</url>
+        <hash>SHA1:aa66b3e03f924265f011044747b54de967cecde4</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</info>
+        <date>2018-01-19</date>
+        <size>2106780</size>
+        <not-before-version>2.7.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>&gt;=2.0.0 &amp; &lt;3.0.0</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_zest>
 </ZAP>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -1,424 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
-	
-    <addon>ascanrules</addon>
-    <addon_ascanrules>
-        <name>Active scanner rules</name>
-        <description>The release quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>31</version>
-        <file>ascanrules-release-31.zap</file>
-        <status>release</status>
-        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
-    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
-    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
-        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
-        <date>2018-03-05</date>
-        <size>635944</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_ascanrules>
-
-    <addon>attacksurfacedetector</addon>
-    <addon_attacksurfacedetector>
-        <name>Attack Surface Detector</name>
-        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
-        <author>Secure Decisions (Matthew DeLetto)</author>
-        <version>1.1.1</version>
-        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
-        <status>alpha</status>
-        <changes>First Version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
-        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
-        <date>2018-06-28</date>
-        <size>14387774</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_attacksurfacedetector>
-    
-    <addon>coreLang</addon>
-    <addon_coreLang>
-        <name>Core Language Files</name>
-        <description>Translations of the core language files</description>
-        <author>ZAP Dev Team</author>
-        <version>13</version>
-        <file>coreLang-release-13.zap</file>
-        <status>release</status>
-        <changes>Added help file with credits.&lt;br&gt;
-	Updated the languages files from Crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/coreLang-release-13.zap</url>
-        <hash>SHA1:8074521b78c3fc9d63e0543ca3887afa2424167e</hash>
-        <info>https://crowdin.com/project/owasp-zap</info>
-        <date>2018-01-15</date>
-        <size>3221988</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_coreLang>
-    
-    <addon>directorylistv1</addon>
-    <addon_directorylistv1>
-        <name>Directory List v1.0</name>
-        <description>List of directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv1-release-3.zap</file>
-        <status>release</status>
-        <changes>Removed repeated files.&lt;br&gt;
-	Added strings for version control directories of Git, Mercurial, SVN, CVS, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv1-release-3.zap</url>
-        <hash>SHA1:b1697b64f5bc50f6bfcb4047b37789850cc3e252</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>847619</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv1>
-    
-    <addon>directorylistv2_3</addon>
-    <addon_directorylistv2_3>
-        <name>Directory List v2.3</name>
-        <description>Lists of directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv2_3-release-3.zap</file>
-        <status>release</status>
-        <changes>Removed repeated files.&lt;br&gt;
-	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3-release-3.zap</url>
-        <hash>SHA1:e3b9cb6a9bae87a0dbcf73ff52f7b4406486d5c0</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>8608734</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv2_3>
-    
-    <addon>directorylistv2_3_lc</addon>
-    <addon_directorylistv2_3_lc>
-        <name>Directory List v2.3 LC</name>
-        <description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>directorylistv2_3_lc-release-3.zap</file>
-        <status>release</status>
-        <changes>Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3_lc-release-3.zap</url>
-        <hash>SHA1:03a5ec11530203be6625633821ab3c05754b2daa</hash>
-        <info>https://owasp.org/index.php/DirBuster</info>
-        <date>2017-11-27</date>
-        <size>7454767</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_directorylistv2_3_lc>
-    
-    <addon>fuzzdb</addon>
-    <addon_fuzzdb>
-        <name>FuzzDB files</name>
-        <description>FuzzDB files which can be used with the ZAP fuzzer</description>
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
+    <addon>accessControl</addon>
+    <addon_accessControl>
+        <name>Access Control Testing</name>
+        <description>Adds a set of tools for testing access control in web applications.</description>
         <author>ZAP Dev Team</author>
         <version>4</version>
-        <file>fuzzdb-release-4.zap</file>
-        <status>release</status>
-        <changes>Update FuzzDB files.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzzdb-release-4.zap</url>
-        <hash>SHA1:6da7ce962bae6b54954415eb71059467e93f14f6</hash>
-        <info>https://github.com/fuzzdb-project/fuzzdb/</info>
-        <date>2017-11-27</date>
-        <size>5627107</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_fuzzdb>
-    
-    <addon>gettingStarted</addon>
-    <addon_gettingStarted>
-        <name>Getting Started with ZAP Guide</name>
-        <description>A short Getting Started with ZAP Guide</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>gettingStarted-release-9.zap</file>
-        <status>release</status>
-        <changes>Added the Spanish, Filipino and Indonesian translations</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/gettingStarted-release-9.zap</url>
-        <hash>SHA1:85108d1ae8df5baae37e62a8494d774a32268782</hash>
-        <date>2018-02-13</date>
-        <size>1623605</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_gettingStarted>
-
-    <addon>groovy</addon>
-    <addon_groovy>
-        <name>Groovy Scripting</name>
-        <description>Allows Groovy to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>groovy-alpha-2.zap</file>
+        <file>accessControl-alpha-4.zap</file>
         <status>alpha</status>
-        <changes>Add help.&lt;br&gt;
-    Added script templates.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/groovy-alpha-2.zap</url>
-        <hash>SHA1:7f0d54eaf987a435e941a422378c124f3fd29259</hash>
-        <date>2018-04-19</date>
-        <size>7334399</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_groovy>
-    
-    <addon>help</addon>
-    <addon_help>
-        <name>Help - English</name>
-        <description>English (master) version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>8</version>
-        <file>help-release-8.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help-release-8.zap</url>
-        <hash>SHA1:137c6627366d86e4629d32aa066e0ebf457ebfe3</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpIntro</info>
-        <date>2017-11-27</date>
-        <size>725234</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help>
-    
-    <addon>help_es_ES</addon>
-    <addon_help_es_ES>
-        <name>Help - Spanish</name>
-        <description>Spanish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>9</version>
-        <file>help_es_ES-release-9.zap</file>
-        <status>release</status>
-        <changes>Updated with the latest files from crowdin, promoted to release</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_es_ES-release-9.zap</url>
-        <hash>SHA1:c17a1d63de54a99feb5344ea3f07e66dcbd7d4d1</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>810573</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_es_ES>
-
-    <addon>help_pt_BR</addon>
-    <addon_help_pt_BR>
-        <name>Help - Portuguese, Brazilian</name>
-        <description>Portuguese, Brazilian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>10</version>
-        <file>help_pt_BR-release-10.zap</file>
-        <status>release</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_pt_BR-release-10.zap</url>
-        <hash>SHA1:43ef048b4faff32e6ed59dfbd07174ceec71bbdb</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>793044</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_pt_BR>
-
-    <addon>help_tr_TR</addon>
-    <addon_help_tr_TR>
-        <name>Help - Turkish</name>
-        <description>Turkish version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>1</version>
-        <file>help_tr_TR-release-1.zap</file>
-        <status>release</status>
-        <changes>First version</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_tr_TR-release-1.zap</url>
-        <hash>SHA1:2d4c3c115e0f401c37049dd1802f413b42f88e5e</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>815439</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_tr_TR>
-    
-    <addon>onlineMenu</addon>
-    <addon_onlineMenu>
-        <name>Online menus</name>
-        <description>ZAP Online menu items</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>onlineMenu-release-6.zap</file>
-        <status>release</status>
         <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/onlineMenu-release-6.zap</url>
-        <hash>SHA1:343c6f9891b311739770bbb3e25d12c766bd1866</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</info>
-        <date>2017-11-27</date>
-        <size>206306</size>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/accessControl-alpha-4.zap</url>
+        <hash>SHA1:c5e590e41dfeec29026956a1e08c0f8b024c0dc4</hash>
+        <date>2017-11-28</date>
+        <size>513559</size>
         <not-before-version>2.7.0</not-before-version>
-    </addon_onlineMenu>
-    
-    <addon>pscanrules</addon>
-    <addon_pscanrules>
-        <name>Passive scanner rules</name>
-        <description>The release quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>22</version>
-        <file>pscanrules-release-22.zap</file>
-        <status>release</status>
-        <changes>Retired the password auto-complete passive scan rule (Issue 4215).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrules-release-22.zap</url>
-        <hash>SHA1:3a3203bcbca8b9091baf12bb5ddf4ec192a15295</hash>
-        <date>2018-01-19</date>
-        <size>518316</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_pscanrules>
-    
-    <addon>quickstart</addon>
-    <addon_quickstart>
-        <name>Quick Start</name>
-        <description>Provides a tab which allows you to quickly test a target application</description>
-        <author>ZAP Dev Team</author>
-        <version>23</version>
-        <file>quickstart-release-23.zap</file>
-        <status>release</status>
-        <changes>Update for 2.7.0.&lt;br&gt;
-    Stop the quick scan if the session is changed.&lt;br&gt;
-    Added toolbar button to launch the latest browser chosen.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/quickstart-release-23.zap</url>
-        <hash>SHA1:34aed4c9a93220978799aff7002236a669c02b25</hash>
-        <date>2018-01-19</date>
-        <size>436181</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_quickstart>
-    
-    <addon>reveal</addon>
-    <addon_reveal>
-        <name>Reveal</name>
-        <description>Show hidden fields and enable disabled fields</description>
-        <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>reveal-release-2.zap</file>
-        <status>release</status>
-        <changes>Code changes and API documentation.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/reveal-release-2.zap</url>
-        <hash>SHA1:caec390697cdc2c82945371e80901af05cc2bfbc</hash>
-        <date>2017-11-27</date>
-        <size>230262</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_reveal>
-    
-    <addon>saverawmessage</addon>
-    <addon_saverawmessage>
-        <name>Save Raw Message</name>
-        <description>Allows to save content of HTTP messages as binary</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>saverawmessage-release-4.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/saverawmessage-release-4.zap</url>
-        <hash>SHA1:df600792159042a452e3e9215d9b89b21417bf88</hash>
-        <date>2017-11-27</date>
-        <size>27756</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_saverawmessage>
-
-    <addon>savexmlmessage</addon>
-    <addon_savexmlmessage>
-        <name>Save XML Message</name>
-        <description>Allows to save content of HTTP messages as XML</description>
-        <author>thatsn0tmysite</author>
-        <version>0.0.1</version>
-        <file>savexmlmessage-alpha-0.0.1.zap</file>
-        <status>alpha</status>
-        <changes>Initial release.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/savexmlmessage-alpha-0.0.1.zap</url>
-        <hash>SHA1:5a819610819e4edc227df5da4dac3c886f2b2d29</hash>
-        <date>2018-05-30</date>
-        <size>12873</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_savexmlmessage>
-    
-    <addon>selenium</addon>
-    <addon_selenium>
-        <name>Selenium</name>
-        <description>WebDriver provider and includes HtmlUnit browser</description>
-        <author>ZAP Dev Team</author>
-        <version>13</version>
-        <semver>2.0.0</semver>
-        <file>selenium-release-13.zap</file>
-        <status>release</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/selenium-release-13.zap</url>
-        <hash>SHA1:27805e3b31a189d0377d359d0c9551dc820adde0</hash>
-        <date>2017-11-27</date>
-        <size>22796677</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_selenium>
-    
-    <addon>spiderAjax</addon>
-    <addon_spiderAjax>
-        <name>Ajax Spider</name>
-        <description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
-        <author>ZAP Dev Team</author>
-        <version>21</version>
-        <file>spiderAjax-release-21.zap</file>
-        <status>release</status>
-        <changes>Reset API scan also when in daemon mode (Issue 4163).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/spiderAjax-release-21.zap</url>
-        <hash>SHA1:92f5a3ecded1d5e0f3b889b07656f5ec8414ada0</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</info>
-        <date>2018-01-19</date>
-        <size>2597145</size>
-        <not-before-version>2.7.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>2.*</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_spiderAjax>
-    
-    <addon>websocket</addon>
-    <addon_websocket>
-        <name>WebSockets</name>
-        <description>Allows you to inspect WebSocket communication.</description>
-        <author>ZAP Dev Team</author>
-        <version>16</version>
-        <file>websocket-release-16.zap</file>
-        <status>release</status>
-        <changes>Tweak About help page.&lt;br&gt;
-    Remove event consumers when the channel is closed.&lt;br&gt;
-    Don't enable the sender scripts by default.&lt;br&gt;
-    Fix send of CLOSE messages with message editor (Issue 4657).&lt;br&gt;
-    Add missing error message.&lt;br&gt;
-    Fix removal of pop up menu items.&lt;br&gt;
-    Allow to filter by payload in WebSocket tab (Issue 1382).&lt;br&gt;
-    Show string representation of binary payloads in WebSocket tab and message panels.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/websocket-release-16.zap</url>
-        <hash>SHA1:6cf3f4d5d7d12813f34e09339d90bf4353d16ed3</hash>
-        <date>2018-06-05</date>
-        <size>928242</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_websocket>
-	
+    </addon_accessControl>
     <addon>alertFilters</addon>
     <addon_alertFilters>
         <name>Context Alert Filters</name>
@@ -434,7 +60,6 @@
         <size>300077</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_alertFilters>
-
     <addon>alertReport</addon>
     <addon_alertReport>
         <name>Report alert generator</name>
@@ -452,505 +77,6 @@
         <size>9722880</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_alertReport>
-
-    <addon>ascanrulesBeta</addon>
-    <addon_ascanrulesBeta>
-        <name>Active scanner rules (beta)</name>
-        <description>The beta quality Active Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>23</version>
-        <file>ascanrulesBeta-beta-23.zap</file>
-        <status>beta</status>
-        <changes>At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrulesBeta-beta-23.zap</url>
-        <hash>SHA1:b3749aae5675fb48b01abc64687f52848d00bc0e</hash>
-        <date>2018-01-19</date>
-        <size>2774403</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_ascanrulesBeta>
-
-    <addon>beanshell</addon>
-    <addon_beanshell>
-        <name>BeanShell Console</name>
-        <description>Provides a BeanShell Console</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>beanshell-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/beanshell-beta-6.zap</url>
-        <hash>SHA1:9546aad4694ef047822bc17d3d9f532d3aa162b8</hash>
-        <date>2017-11-27</date>
-        <size>574028</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_beanshell>
-
-    <addon>bruteforce</addon>
-    <addon_bruteforce>
-        <name>Forced Browse</name>
-        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
-        <author>ZAP Dev Team</author>
-        <version>7</version>
-        <file>bruteforce-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/bruteforce-beta-7.zap</url>
-        <hash>SHA1:4f28d919b7e8765a9acb3eaba5607d607f8b3710</hash>
-        <date>2017-11-27</date>
-        <size>1011548</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_bruteforce>
-
-    <addon>diff</addon>
-    <addon_diff>
-        <name>Diff</name>
-        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>diff-beta-8.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/diff-beta-8.zap</url>
-        <hash>SHA1:d76cfd841c5893faba628a1b45d27592cbeab291</hash>
-        <date>2017-11-27</date>
-        <size>241225</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_diff>
-
-    <addon>fuzz</addon>
-    <addon_fuzz>
-        <name>AdvFuzzer</name>
-        <description>Advanced fuzzer for manual testing</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <semver>2.0.1</semver>
-        <file>fuzz-beta-10.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzz-beta-10.zap</url>
-        <hash>SHA1:eb87f3fd76c7691b514b4977c81bcaa8cc3bae79</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
-        <date>2017-11-27</date>
-        <size>2418608</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_fuzz>
-
-    <addon>help_id_ID</addon>
-    <addon_help_id_ID>
-        <name>Help Indonesian</name>
-        <description>Indonesian version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>2</version>
-        <file>help_id_ID-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_id_ID-beta-2.zap</url>
-        <hash>SHA1:7b7ba465a1eecac23781582a1f1d7dfbaef2d347</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>775452</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_id_ID>
-
-    <addon>help_ja_JP</addon>
-    <addon_help_ja_JP>
-        <name>Help - Japanese</name>
-        <description>Japanese version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>9</version>
-        <file>help_ja_JP-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_ja_JP-beta-9.zap</url>
-        <hash>SHA1:d91450eef7e4f3ce19fa9ad9f318fb80cc337ec1</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>774034</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_ja_JP>
-
-    <addon>help_zh_CN</addon>
-    <addon_help_zh_CN>
-        <name>Help Chinese Simplified</name>
-        <description>Chinese Simplified version of the ZAP help file.</description>
-        <author>ZAP Crowdin Team</author>
-        <version>2</version>
-        <file>help_zh_CN-beta-2.zap</file>
-        <status>beta</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_zh_CN-beta-2.zap</url>
-        <hash>SHA1:bf58e29e3813b20df90e1691e81119e4a1a2e4f2</hash>
-        <info>https://crowdin.com/project/owasp-zap-help</info>
-        <date>2018-02-08</date>
-        <size>761680</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_help_zh_CN>
-
-    <addon>imagelocationscanner</addon>
-    <addon_imagelocationscanner>
-        <name>Image Location and Privacy Scanner</name>
-        <description>Image Location and Privacy Passive Scanner</description>
-        <author>Veggiespam and the ZAP Dev Team</author>
-        <version>1</version>
-        <file>imagelocationscanner-beta-1.zap</file>
-        <status>beta</status>
-        <changes>Promoted to beta and separated from the passive scan alpha add-on.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/imagelocationscanner-beta-1.zap</url>
-        <hash>SHA1:5fcd1183e055406b8dd725f434044ef73323f48f</hash>
-        <date>2018-02-27</date>
-        <size>607798</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_imagelocationscanner>
-
-    <addon>importurls</addon>
-    <addon_importurls>
-        <name>Import files containing URLs</name>
-        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
-        <author>ZAP Dev Team</author>
-        <version>5</version>
-        <file>importurls-beta-5.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/importurls-beta-5.zap</url>
-        <hash>SHA1:fc1386d20cf70a7aa42655303d22479009fa9a89</hash>
-        <date>2017-11-27</date>
-        <size>225043</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_importurls>
-
-    <addon>invoke</addon>
-    <addon_invoke>
-        <name>Invoke Applications</name>
-        <description>Invoke external applications passing context related information such as URLs and parameters</description>
-        <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>invoke-beta-9.zap</file>
-        <status>beta</status>
-        <changes>Added additional parameter replacements of %msgid% and %header-*%&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/invoke-beta-9.zap</url>
-        <hash>SHA1:81df2e9d7794b273410c87336ef66cb4cc4dc6b6</hash>
-        <date>2018-02-19</date>
-        <size>314763</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_invoke>
-
-    <addon>jruby</addon>
-    <addon_jruby>
-        <name>Ruby scripting</name>
-        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>jruby-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jruby-beta-6.zap</url>
-        <hash>SHA1:99166f0e9f4337329ae8452da032986214f1eb73</hash>
-        <date>2017-11-27</date>
-        <size>22477473</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_jruby>
-
-    <addon>jsonview</addon>
-    <addon_jsonview>
-        <name>Json view</name>
-        <description>Adds a view that shows JSON messages nicely formatted</description>
-        <author>Juha Kivekäs</author>
-        <version>1</version>
-        <file>jsonview-alpha-1.zap</file>
-        <status>alpha</status>
-        <changes>Initial release</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jsonview-alpha-1.zap</url>
-        <hash>SHA1:be9a95e39722ff42af1160a195a56c9af9e285c1</hash>
-        <date>2018-02-08</date>
-        <size>10796</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_jsonview>
-
-    <addon>jython</addon>
-    <addon_jython>
-        <name>Python Scripting</name>
-        <description>Allows Python to be used for ZAP scripting - templates included</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>jython-beta-10.zap</file>
-        <status>beta</status>
-        <changes>Correctly set path module defined in the options and address UI hang (Issue 4651).&lt;br&gt;
-    Minor tweak in extender template.&lt;br&gt;
-    Add default template for Script Input Vector.&lt;br&gt;
-    Add help page for the options.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jython-beta-10.zap</url>
-        <hash>SHA1:fedf4e6c30dfb52543d851bb668ab1c8101dd58f</hash>
-        <date>2018-05-08</date>
-        <size>41738465</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_jython>
-
-    <addon>plugnhack</addon>
-    <addon_plugnhack>
-        <name>Plug-n-Hack Configuration</name>
-        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
-        <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>plugnhack-beta-11.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/plugnhack-beta-11.zap</url>
-        <hash>SHA1:e3243495919a8d1a7f4bd69e60b7147690bb9836</hash>
-        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
-        <date>2017-11-27</date>
-        <size>722977</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_plugnhack>
-
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>8</version>
-        <file>portscan-beta-8.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
-	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/portscan-beta-8.zap</url>
-        <hash>SHA1:85b7377c65778d22a4c78fe1ff79b82245abc4c9</hash>
-        <date>2017-11-27</date>
-        <size>632994</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_portscan>
-
-    <addon>pscanrulesBeta</addon>
-    <addon_pscanrulesBeta>
-        <name>Passive scanner rules (beta)</name>
-        <description>The beta quality Passive Scanner rules</description>
-        <author>ZAP Dev Team</author>
-        <version>18</version>
-        <file>pscanrulesBeta-beta-18.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes to address deprecation.&lt;br/&gt;
-    At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).&lt;br/&gt;
-        Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).&lt;br/&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrulesBeta-beta-18.zap</url>
-        <hash>SHA1:caf60a429ff6c7c6f53fab09f94462a9c6e30150</hash>
-        <date>2018-01-19</date>
-        <size>559591</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_pscanrulesBeta>
-
-    <addon>replacer</addon>
-    <addon_replacer>
-        <name>Replacer</name>
-        <description>Easy way to replace strings in requests and responses.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>replacer-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Tweak help page.&lt;br&gt;
-    Ignore CFU HTTP messages.&lt;br&gt;
-    Allow to (explicitly) select Token Generator messages.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/replacer-beta-6.zap</url>
-        <hash>SHA1:94d43eee92dbbcf7854f64dd60c713c1a580e5ba</hash>
-        <date>2018-06-12</date>
-        <size>330710</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_replacer>
-
-    <addon>scripts</addon>
-    <addon_scripts>
-        <name>Script Console</name>
-        <description>Supports all JSR 223 scripting languages</description>
-        <author>ZAP Dev Team</author>
-        <version>24</version>
-        <file>scripts-beta-24.zap</file>
-        <status>beta</status>
-        <changes>Fix GUI freeze on script addition/removal through the API (Issue 4302).&lt;br&gt;
-    Prompt for a charset when failed to read the script file (Issue 3383).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/scripts-beta-24.zap</url>
-        <hash>SHA1:63295325786e27ee0d5920bb46656eda7ea1f514</hash>
-        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
-        <date>2018-01-25</date>
-        <size>639756</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_scripts>
-
-    <addon>sqliplugin</addon>
-    <addon_sqliplugin>
-        <name>Advanced SQLInjection Scanner</name>
-        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
-        <author>Andrea Pompili (Yhawke)</author>
-        <version>12</version>
-        <file>sqliplugin-beta-12.zap</file>
-        <status>beta</status>
-        <changes>Minor code changes.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/sqliplugin-beta-12.zap</url>
-        <hash>SHA1:7661c839f8ab0fa731d6629de1b7526b706d6bb6</hash>
-        <date>2017-11-27</date>
-        <size>119265</size>
-        <not-before-version>2.4.1</not-before-version>
-    </addon_sqliplugin>
-
-    <addon>svndigger</addon>
-    <addon_svndigger>
-        <name>SVN Digger files</name>
-        <description>SVN Digger files which can be used with ZAP forced browsing</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>svndigger-beta-3.zap</file>
-        <status>beta</status>
-        <changes>Updated for ZAP 2.4</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/svndigger-beta-3.zap</url>
-        <hash>SHA1:8c7187180ed48466d6829e39469cc3d0915b1cbf</hash>
-        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
-        <date>2017-11-27</date>
-        <size>615459</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_svndigger>
-
-    <addon>tips</addon>
-    <addon_tips>
-        <name>Tips and Tricks</name>
-        <description>Display ZAP Tips and Tricks</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>tips-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Updated for 2.7.0.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tips-beta-6.zap</url>
-        <hash>SHA1:b6a560a292fa21b867a5c2385bfab0afcdfe0cd5</hash>
-        <date>2017-11-27</date>
-        <size>517219</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_tips>
-
-    <addon>tokengen</addon>
-    <addon_tokengen>
-        <name>Token generation and analysis</name>
-        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
-        <author>ZAP Dev Team</author>
-        <version>12</version>
-        <file>tokengen-beta-12.zap</file>
-        <status>beta</status>
-        <changes>Stop the test and clear the panel on session changes.&lt;br&gt;
-    Respect the current mode and react to changes.&lt;br&gt;
-    Inform of running test (e.g. on session change, add-on uninstall).&lt;br&gt;
-    Allow to configure the number of threads.&lt;br&gt;
-    Allow to delay the requests.&lt;br&gt;
-    Update minimum ZAP version to 2.6.0.&lt;br&gt;
-    Deletes the cookie in question before sending the request.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tokengen-beta-12.zap</url>
-        <hash>SHA1:71bb8a5bc15fe725b5ba38939559696589782583</hash>
-        <date>2018-05-17</date>
-        <size>323564</size>
-        <not-before-version>2.6.0</not-before-version>
-    </addon_tokengen>
-
-    <addon>treetools</addon>
-    <addon_treetools>
-        <name>TreeTools</name>
-        <description>Tools to add functionality to the tree view.</description>
-        <author>Carl Sampson</author>
-        <version>7</version>
-        <file>treetools-beta-7.zap</file>
-        <status>beta</status>
-        <changes>Code changes for Java 9 (Issue 2602)</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/treetools-beta-7.zap</url>
-        <hash>SHA1:38fbc4d4e22c0da73a4048522d250fa4ac89bdab</hash>
-        <date>2017-11-27</date>
-        <size>18821</size>
-        <not-before-version>2.4.0</not-before-version>
-    </addon_treetools>
-
-    <addon>webdriverlinux</addon>
-    <addon_webdriverlinux>
-        <name>Linux WebDrivers</name>
-        <description>Linux WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdriverlinux-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverlinux-beta-6.zap</url>
-        <hash>SHA1:ff062a3bc9869880d41f3e20587a388a403a8af9</hash>
-        <date>2018-06-11</date>
-        <size>9249857</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdriverlinux>
-    <addon>webdrivermacos</addon>
-
-    <addon_webdrivermacos>
-        <name>MacOS WebDrivers</name>
-        <description>MacOS WebDrivers for Firefox and Chrome.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdrivermacos-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdrivermacos-beta-6.zap</url>
-        <hash>SHA1:ce59ca4b71b776c3a9d8825a65fe613edf45f897</hash>
-        <date>2018-06-11</date>
-        <size>7228885</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdrivermacos>
-
-    <addon>webdriverwindows</addon>
-    <addon_webdriverwindows>
-        <name>Windows WebDrivers</name>
-        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
-        <author>ZAP Dev Team</author>
-        <version>6</version>
-        <file>webdriverwindows-beta-6.zap</file>
-        <status>beta</status>
-        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverwindows-beta-6.zap</url>
-        <hash>SHA1:7fa7c1dbb6812031c52c85e8de4767671921e2e0</hash>
-        <date>2018-06-11</date>
-        <size>10943223</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_webdriverwindows>
-
-    <addon>zest</addon>
-    <addon_zest>
-        <name>Zest - Graphical Security Scripting Language</name>
-        <description>A graphical security scripting language, ZAPs macro language on steroids</description>
-        <author>ZAP Dev Team</author>
-        <version>27</version>
-        <file>zest-beta-27.zap</file>
-        <status>beta</status>
-        <changes>Fix exception when editing Action - Script with unsaved scripts.&lt;br&gt;
-    Allow to select more HTTP methods in Zest Request dialogue.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/zest-beta-27.zap</url>
-        <hash>SHA1:aa66b3e03f924265f011044747b54de967cecde4</hash>
-        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</info>
-        <date>2018-01-19</date>
-        <size>2106780</size>
-        <not-before-version>2.7.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>selenium</id>
-                    <semver>&gt;=2.0.0 &amp; &lt;3.0.0</semver>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_zest>
-
-    <addon>accessControl</addon>
-    <addon_accessControl>
-        <name>Access Control Testing</name>
-        <description>Adds a set of tools for testing access control in web applications.</description>
-        <author>ZAP Dev Team</author>
-        <version>4</version>
-        <file>accessControl-alpha-4.zap</file>
-        <status>alpha</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/accessControl-alpha-4.zap</url>
-        <hash>SHA1:c5e590e41dfeec29026956a1e08c0f8b024c0dc4</hash>
-        <date>2017-11-28</date>
-        <size>513559</size>
-        <not-before-version>2.7.0</not-before-version>
-    </addon_accessControl>
-
     <addon>amf</addon>
     <addon_amf>
         <name>AMF</name>
@@ -966,7 +92,23 @@
         <size>813490</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_amf>
-
+    <addon>ascanrules</addon>
+    <addon_ascanrules>
+        <name>Active scanner rules</name>
+        <description>The release quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>31</version>
+        <file>ascanrules-release-31.zap</file>
+        <status>release</status>
+        <changes>Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.&lt;br/&gt;
+    Issue 1640: Fix reflected XSS false negative with double decoded output.&lt;br/&gt;
+    Issue 2290: Fix SQLi false negative with ODBC error message.&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrules-release-31.zap</url>
+        <hash>SHA1:f89690aaf60e13c384c86b1899e56bc2ac4820e8</hash>
+        <date>2018-03-05</date>
+        <size>635944</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_ascanrules>
     <addon>ascanrulesAlpha</addon>
     <addon_ascanrulesAlpha>
         <name>Active scanner rules (alpha)</name>
@@ -986,7 +128,36 @@
         <size>1594615</size>
         <not-before-version>2.4.1</not-before-version>
     </addon_ascanrulesAlpha>
-
+    <addon>ascanrulesBeta</addon>
+    <addon_ascanrulesBeta>
+        <name>Active scanner rules (beta)</name>
+        <description>The beta quality Active Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>23</version>
+        <file>ascanrulesBeta-beta-23.zap</file>
+        <status>beta</status>
+        <changes>At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/ascanrulesBeta-beta-23.zap</url>
+        <hash>SHA1:b3749aae5675fb48b01abc64687f52848d00bc0e</hash>
+        <date>2018-01-19</date>
+        <size>2774403</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_ascanrulesBeta>
+    <addon>attacksurfacedetector</addon>
+    <addon_attacksurfacedetector>
+        <name>Attack Surface Detector</name>
+        <description>The Attack Surface Detector analyzes web application source code to generate endpoints that can be used for penetration testing.</description>
+        <author>Secure Decisions (Matthew DeLetto)</author>
+        <version>1.1.1</version>
+        <file>attacksurfacedetector-alpha-1.1.1.zap</file>
+        <status>alpha</status>
+        <changes>First Version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/attacksurfacedetector-alpha-1.1.1.zap</url>
+        <hash>SHA1:15348902ae1d3eb5eadfaeeab6c4218e22f923e3</hash>
+        <date>2018-06-28</date>
+        <size>14387774</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_attacksurfacedetector>
     <addon>authstats</addon>
     <addon_authstats>
         <name>Authentication Statistics</name>
@@ -1003,7 +174,21 @@
         <size>238686</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_authstats>
-
+    <addon>beanshell</addon>
+    <addon_beanshell>
+        <name>BeanShell Console</name>
+        <description>Provides a BeanShell Console</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>beanshell-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/beanshell-beta-6.zap</url>
+        <hash>SHA1:9546aad4694ef047822bc17d3d9f532d3aa162b8</hash>
+        <date>2017-11-27</date>
+        <size>574028</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_beanshell>
     <addon>browserView</addon>
     <addon_browserView>
         <name>Browser View</name>
@@ -1019,7 +204,22 @@
         <size>193880</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_browserView>
-
+    <addon>bruteforce</addon>
+    <addon_bruteforce>
+        <name>Forced Browse</name>
+        <description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
+        <author>ZAP Dev Team</author>
+        <version>7</version>
+        <file>bruteforce-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/bruteforce-beta-7.zap</url>
+        <hash>SHA1:4f28d919b7e8765a9acb3eaba5607d607f8b3710</hash>
+        <date>2017-11-27</date>
+        <size>1011548</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_bruteforce>
     <addon>bugtracker</addon>
     <addon_bugtracker>
         <name>Bug Tracker</name>
@@ -1035,7 +235,6 @@
         <size>2002624</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_bugtracker>
-
     <addon>callgraph</addon>
     <addon_callgraph>
         <name>Call Graph</name>
@@ -1051,7 +250,6 @@
         <size>1160586</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_callgraph>
-
     <addon>cmss</addon>
     <addon_cmss>
         <name>WAFP Extension</name>
@@ -1068,7 +266,6 @@
         <size>545349</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_cmss>
-
     <addon>codedx</addon>
     <addon_codedx>
         <name>Code Dx Extension</name>
@@ -1086,7 +283,6 @@
         <size>1415674</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_codedx>
-
     <addon>communityScripts</addon>
     <addon_communityScripts>
         <name>Community Scripts</name>
@@ -1103,7 +299,23 @@
         <size>387552</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_communityScripts>
-
+    <addon>coreLang</addon>
+    <addon_coreLang>
+        <name>Core Language Files</name>
+        <description>Translations of the core language files</description>
+        <author>ZAP Dev Team</author>
+        <version>13</version>
+        <file>coreLang-release-13.zap</file>
+        <status>release</status>
+        <changes>Added help file with credits.&lt;br&gt;
+	Updated the languages files from Crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/coreLang-release-13.zap</url>
+        <hash>SHA1:8074521b78c3fc9d63e0543ca3887afa2424167e</hash>
+        <info>https://crowdin.com/project/owasp-zap</info>
+        <date>2018-01-15</date>
+        <size>3221988</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_coreLang>
     <addon>cspscanner</addon>
     <addon_cspscanner>
         <name>Content Security Policy Scanner</name>
@@ -1121,7 +333,6 @@
         <size>176663</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_cspscanner>
-
     <addon>customreport</addon>
     <addon_customreport>
         <name>CustomReport</name>
@@ -1138,7 +349,71 @@
         <size>575782</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_customreport>
-
+    <addon>diff</addon>
+    <addon_diff>
+        <name>Diff</name>
+        <description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>diff-beta-8.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/diff-beta-8.zap</url>
+        <hash>SHA1:d76cfd841c5893faba628a1b45d27592cbeab291</hash>
+        <date>2017-11-27</date>
+        <size>241225</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_diff>
+    <addon>directorylistv1</addon>
+    <addon_directorylistv1>
+        <name>Directory List v1.0</name>
+        <description>List of directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv1-release-3.zap</file>
+        <status>release</status>
+        <changes>Removed repeated files.&lt;br&gt;
+	Added strings for version control directories of Git, Mercurial, SVN, CVS, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv1-release-3.zap</url>
+        <hash>SHA1:b1697b64f5bc50f6bfcb4047b37789850cc3e252</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>847619</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv1>
+    <addon>directorylistv2_3</addon>
+    <addon_directorylistv2_3>
+        <name>Directory List v2.3</name>
+        <description>Lists of directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv2_3-release-3.zap</file>
+        <status>release</status>
+        <changes>Removed repeated files.&lt;br&gt;
+	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3-release-3.zap</url>
+        <hash>SHA1:e3b9cb6a9bae87a0dbcf73ff52f7b4406486d5c0</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>8608734</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv2_3>
+    <addon>directorylistv2_3_lc</addon>
+    <addon_directorylistv2_3_lc>
+        <name>Directory List v2.3 LC</name>
+        <description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>directorylistv2_3_lc-release-3.zap</file>
+        <status>release</status>
+        <changes>Added strings for version control directories of Git, Mercurial, SVN, Bazaar.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/directorylistv2_3_lc-release-3.zap</url>
+        <hash>SHA1:03a5ec11530203be6625633821ab3c05754b2daa</hash>
+        <info>https://owasp.org/index.php/DirBuster</info>
+        <date>2017-11-27</date>
+        <size>7454767</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_directorylistv2_3_lc>
     <addon>domxss</addon>
     <addon_domxss>
         <name>DOM XSS Active scanner rule</name>
@@ -1162,7 +437,6 @@
             </addons>
         </dependencies>
     </addon_domxss>
-
     <addon>exportreport</addon>
     <addon_exportreport>
         <name>Export Report</name>
@@ -1178,7 +452,6 @@
         <size>6402380</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_exportreport>
-
     <addon>formhandler</addon>
     <addon_formhandler>
         <name>Form Handler</name>
@@ -1194,7 +467,86 @@
         <size>2121043</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_formhandler>
-
+    <addon>fuzz</addon>
+    <addon_fuzz>
+        <name>AdvFuzzer</name>
+        <description>Advanced fuzzer for manual testing</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <semver>2.0.1</semver>
+        <file>fuzz-beta-10.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzz-beta-10.zap</url>
+        <hash>SHA1:eb87f3fd76c7691b514b4977c81bcaa8cc3bae79</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</info>
+        <date>2017-11-27</date>
+        <size>2418608</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_fuzz>
+    <addon>fuzzdb</addon>
+    <addon_fuzzdb>
+        <name>FuzzDB files</name>
+        <description>FuzzDB files which can be used with the ZAP fuzzer</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>fuzzdb-release-4.zap</file>
+        <status>release</status>
+        <changes>Update FuzzDB files.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/fuzzdb-release-4.zap</url>
+        <hash>SHA1:6da7ce962bae6b54954415eb71059467e93f14f6</hash>
+        <info>https://github.com/fuzzdb-project/fuzzdb/</info>
+        <date>2017-11-27</date>
+        <size>5627107</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_fuzzdb>
+    <addon>gettingStarted</addon>
+    <addon_gettingStarted>
+        <name>Getting Started with ZAP Guide</name>
+        <description>A short Getting Started with ZAP Guide</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>gettingStarted-release-9.zap</file>
+        <status>release</status>
+        <changes>Added the Spanish, Filipino and Indonesian translations</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/gettingStarted-release-9.zap</url>
+        <hash>SHA1:85108d1ae8df5baae37e62a8494d774a32268782</hash>
+        <date>2018-02-13</date>
+        <size>1623605</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_gettingStarted>
+    <addon>groovy</addon>
+    <addon_groovy>
+        <name>Groovy Scripting</name>
+        <description>Allows Groovy to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>groovy-alpha-2.zap</file>
+        <status>alpha</status>
+        <changes>Add help.&lt;br&gt;
+    Added script templates.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/groovy-alpha-2.zap</url>
+        <hash>SHA1:7f0d54eaf987a435e941a422378c124f3fd29259</hash>
+        <date>2018-04-19</date>
+        <size>7334399</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_groovy>
+    <addon>help</addon>
+    <addon_help>
+        <name>Help - English</name>
+        <description>English (master) version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>8</version>
+        <file>help-release-8.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help-release-8.zap</url>
+        <hash>SHA1:137c6627366d86e4629d32aa066e0ebf457ebfe3</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpIntro</info>
+        <date>2017-11-27</date>
+        <size>725234</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help>
     <addon>help_bs_BA</addon>
     <addon_help_bs_BA>
         <name>Help - Bosnian</name>
@@ -1211,24 +563,22 @@
         <size>747536</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_help_bs_BA>
-    
-    <addon>help_fr_FR</addon>
-    <addon_help_fr_FR>
-        <name>Help - French</name>
-        <description>French version of the ZAP help file.</description>
+    <addon>help_es_ES</addon>
+    <addon_help_es_ES>
+        <name>Help - Spanish</name>
+        <description>Spanish version of the ZAP help file.</description>
         <author>ZAP Crowdin Team</author>
         <version>9</version>
-        <file>help_fr_FR-alpha-9.zap</file>
-        <status>alpha</status>
-        <changes>Updated with the latest files from crowdin</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_fr_FR-alpha-9.zap</url>
-        <hash>SHA1:05aa37ec86966990fa33190c65a53d1c5a6dc955</hash>
+        <file>help_es_ES-release-9.zap</file>
+        <status>release</status>
+        <changes>Updated with the latest files from crowdin, promoted to release</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_es_ES-release-9.zap</url>
+        <hash>SHA1:c17a1d63de54a99feb5344ea3f07e66dcbd7d4d1</hash>
         <info>https://crowdin.com/project/owasp-zap-help</info>
         <date>2018-02-08</date>
-        <size>752466</size>
+        <size>810573</size>
         <not-before-version>2.7.0</not-before-version>
-    </addon_help_fr_FR>
-
+    </addon_help_es_ES>
     <addon>help_fil_PH</addon>
     <addon_help_fil_PH>
         <name>Help Filipino</name>
@@ -1245,7 +595,102 @@
         <size>818996</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_help_fil_PH>
-
+    <addon>help_fr_FR</addon>
+    <addon_help_fr_FR>
+        <name>Help - French</name>
+        <description>French version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>9</version>
+        <file>help_fr_FR-alpha-9.zap</file>
+        <status>alpha</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_fr_FR-alpha-9.zap</url>
+        <hash>SHA1:05aa37ec86966990fa33190c65a53d1c5a6dc955</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>752466</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_fr_FR>
+    <addon>help_id_ID</addon>
+    <addon_help_id_ID>
+        <name>Help Indonesian</name>
+        <description>Indonesian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>2</version>
+        <file>help_id_ID-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_id_ID-beta-2.zap</url>
+        <hash>SHA1:7b7ba465a1eecac23781582a1f1d7dfbaef2d347</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>775452</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_id_ID>
+    <addon>help_ja_JP</addon>
+    <addon_help_ja_JP>
+        <name>Help - Japanese</name>
+        <description>Japanese version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>9</version>
+        <file>help_ja_JP-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_ja_JP-beta-9.zap</url>
+        <hash>SHA1:d91450eef7e4f3ce19fa9ad9f318fb80cc337ec1</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>774034</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_ja_JP>
+    <addon>help_pt_BR</addon>
+    <addon_help_pt_BR>
+        <name>Help - Portuguese, Brazilian</name>
+        <description>Portuguese, Brazilian version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>10</version>
+        <file>help_pt_BR-release-10.zap</file>
+        <status>release</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_pt_BR-release-10.zap</url>
+        <hash>SHA1:43ef048b4faff32e6ed59dfbd07174ceec71bbdb</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>793044</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_pt_BR>
+    <addon>help_tr_TR</addon>
+    <addon_help_tr_TR>
+        <name>Help - Turkish</name>
+        <description>Turkish version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>1</version>
+        <file>help_tr_TR-release-1.zap</file>
+        <status>release</status>
+        <changes>First version</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_tr_TR-release-1.zap</url>
+        <hash>SHA1:2d4c3c115e0f401c37049dd1802f413b42f88e5e</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>815439</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_tr_TR>
+    <addon>help_zh_CN</addon>
+    <addon_help_zh_CN>
+        <name>Help Chinese Simplified</name>
+        <description>Chinese Simplified version of the ZAP help file.</description>
+        <author>ZAP Crowdin Team</author>
+        <version>2</version>
+        <file>help_zh_CN-beta-2.zap</file>
+        <status>beta</status>
+        <changes>Updated with the latest files from crowdin</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/help_zh_CN-beta-2.zap</url>
+        <hash>SHA1:bf58e29e3813b20df90e1691e81119e4a1a2e4f2</hash>
+        <info>https://crowdin.com/project/owasp-zap-help</info>
+        <date>2018-02-08</date>
+        <size>761680</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_help_zh_CN>
     <addon>highlighter</addon>
     <addon_highlighter>
         <name>Highlighter</name>
@@ -1263,7 +708,6 @@
         <size>9210</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_highlighter>
-
     <addon>httpsInfo</addon>
     <addon_httpsInfo>
         <name>HttpsInfo</name>
@@ -1279,7 +723,21 @@
         <size>5542543</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_httpsInfo>
-
+    <addon>imagelocationscanner</addon>
+    <addon_imagelocationscanner>
+        <name>Image Location and Privacy Scanner</name>
+        <description>Image Location and Privacy Passive Scanner</description>
+        <author>Veggiespam and the ZAP Dev Team</author>
+        <version>1</version>
+        <file>imagelocationscanner-beta-1.zap</file>
+        <status>beta</status>
+        <changes>Promoted to beta and separated from the passive scan alpha add-on.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/imagelocationscanner-beta-1.zap</url>
+        <hash>SHA1:5fcd1183e055406b8dd725f434044ef73323f48f</hash>
+        <date>2018-02-27</date>
+        <size>607798</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_imagelocationscanner>
     <addon>importLogFiles</addon>
     <addon_importLogFiles>
         <name>Log File Importer</name>
@@ -1296,7 +754,66 @@
         <size>152736</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_importLogFiles>
-
+    <addon>importurls</addon>
+    <addon_importurls>
+        <name>Import files containing URLs</name>
+        <description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
+        <author>ZAP Dev Team</author>
+        <version>5</version>
+        <file>importurls-beta-5.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/importurls-beta-5.zap</url>
+        <hash>SHA1:fc1386d20cf70a7aa42655303d22479009fa9a89</hash>
+        <date>2017-11-27</date>
+        <size>225043</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_importurls>
+    <addon>invoke</addon>
+    <addon_invoke>
+        <name>Invoke Applications</name>
+        <description>Invoke external applications passing context related information such as URLs and parameters</description>
+        <author>ZAP Dev Team</author>
+        <version>9</version>
+        <file>invoke-beta-9.zap</file>
+        <status>beta</status>
+        <changes>Added additional parameter replacements of %msgid% and %header-*%&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/invoke-beta-9.zap</url>
+        <hash>SHA1:81df2e9d7794b273410c87336ef66cb4cc4dc6b6</hash>
+        <date>2018-02-19</date>
+        <size>314763</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_invoke>
+    <addon>jruby</addon>
+    <addon_jruby>
+        <name>Ruby scripting</name>
+        <description>Allows Ruby to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>jruby-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jruby-beta-6.zap</url>
+        <hash>SHA1:99166f0e9f4337329ae8452da032986214f1eb73</hash>
+        <date>2017-11-27</date>
+        <size>22477473</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_jruby>
+    <addon>jsonview</addon>
+    <addon_jsonview>
+        <name>Json view</name>
+        <description>Adds a view that shows JSON messages nicely formatted</description>
+        <author>Juha Kivekäs</author>
+        <version>1</version>
+        <file>jsonview-alpha-1.zap</file>
+        <status>alpha</status>
+        <changes>Initial release</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jsonview-alpha-1.zap</url>
+        <hash>SHA1:be9a95e39722ff42af1160a195a56c9af9e285c1</hash>
+        <date>2018-02-08</date>
+        <size>10796</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_jsonview>
     <addon>jxbrowser</addon>
     <addon_jxbrowser>
         <name>JxBrowser (core)</name>
@@ -1313,7 +830,6 @@
         <size>1481399</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_jxbrowser>
-
     <addon>jxbrowserlinux64</addon>
     <addon_jxbrowserlinux64>
         <name>JxBrowser (Linux 64)</name>
@@ -1339,7 +855,6 @@
             </addons>
         </dependencies>
     </addon_jxbrowserlinux64>
-
     <addon>jxbrowsermacos</addon>
     <addon_jxbrowsermacos>
         <name>JxBrowser (Mac OS)</name>
@@ -1365,7 +880,6 @@
             </addons>
         </dependencies>
     </addon_jxbrowsermacos>
-
     <addon>jxbrowserwindows</addon>
     <addon_jxbrowserwindows>
         <name>JxBrowser (Windows)</name>
@@ -1391,7 +905,40 @@
             </addons>
         </dependencies>
     </addon_jxbrowserwindows>
-
+    <addon>jython</addon>
+    <addon_jython>
+        <name>Python Scripting</name>
+        <description>Allows Python to be used for ZAP scripting - templates included</description>
+        <author>ZAP Dev Team</author>
+        <version>10</version>
+        <file>jython-beta-10.zap</file>
+        <status>beta</status>
+        <changes>Correctly set path module defined in the options and address UI hang (Issue 4651).&lt;br&gt;
+    Minor tweak in extender template.&lt;br&gt;
+    Add default template for Script Input Vector.&lt;br&gt;
+    Add help page for the options.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jython-beta-10.zap</url>
+        <hash>SHA1:fedf4e6c30dfb52543d851bb668ab1c8101dd58f</hash>
+        <date>2018-05-08</date>
+        <size>41738465</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_jython>
+    <addon>onlineMenu</addon>
+    <addon_onlineMenu>
+        <name>Online menus</name>
+        <description>ZAP Online menu items</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>onlineMenu-release-6.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/onlineMenu-release-6.zap</url>
+        <hash>SHA1:343c6f9891b311739770bbb3e25d12c766bd1866</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</info>
+        <date>2017-11-27</date>
+        <size>206306</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_onlineMenu>
     <addon>openapi</addon>
     <addon_openapi>
         <name>OpenAPI Support</name>
@@ -1407,7 +954,53 @@
         <size>3324050</size>
         <not-before-version>2.6.0</not-before-version>
     </addon_openapi>
-
+    <addon>plugnhack</addon>
+    <addon_plugnhack>
+        <name>Plug-n-Hack Configuration</name>
+        <description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
+        <author>ZAP Dev Team</author>
+        <version>11</version>
+        <file>plugnhack-beta-11.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/plugnhack-beta-11.zap</url>
+        <hash>SHA1:e3243495919a8d1a7f4bd69e60b7147690bb9836</hash>
+        <info>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</info>
+        <date>2017-11-27</date>
+        <size>722977</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_plugnhack>
+    <addon>portscan</addon>
+    <addon_portscan>
+        <name>Port Scanner</name>
+        <description>Allows to port scan a target server</description>
+        <author>ZAP Dev Team</author>
+        <version>8</version>
+        <file>portscan-beta-8.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;
+	Issue 3513: Options panel UI fixes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/portscan-beta-8.zap</url>
+        <hash>SHA1:85b7377c65778d22a4c78fe1ff79b82245abc4c9</hash>
+        <date>2017-11-27</date>
+        <size>632994</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_portscan>
+    <addon>pscanrules</addon>
+    <addon_pscanrules>
+        <name>Passive scanner rules</name>
+        <description>The release quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>22</version>
+        <file>pscanrules-release-22.zap</file>
+        <status>release</status>
+        <changes>Retired the password auto-complete passive scan rule (Issue 4215).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrules-release-22.zap</url>
+        <hash>SHA1:3a3203bcbca8b9091baf12bb5ddf4ec192a15295</hash>
+        <date>2018-01-19</date>
+        <size>518316</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_pscanrules>
     <addon>pscanrulesAlpha</addon>
     <addon_pscanrulesAlpha>
         <name>Passive scanner rules (alpha)</name>
@@ -1424,7 +1017,57 @@
         <size>1747326</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_pscanrulesAlpha>
-
+    <addon>pscanrulesBeta</addon>
+    <addon_pscanrulesBeta>
+        <name>Passive scanner rules (beta)</name>
+        <description>The beta quality Passive Scanner rules</description>
+        <author>ZAP Dev Team</author>
+        <version>18</version>
+        <file>pscanrulesBeta-beta-18.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes to address deprecation.&lt;br/&gt;
+    At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).&lt;br/&gt;
+        Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).&lt;br/&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/pscanrulesBeta-beta-18.zap</url>
+        <hash>SHA1:caf60a429ff6c7c6f53fab09f94462a9c6e30150</hash>
+        <date>2018-01-19</date>
+        <size>559591</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_pscanrulesBeta>
+    <addon>quickstart</addon>
+    <addon_quickstart>
+        <name>Quick Start</name>
+        <description>Provides a tab which allows you to quickly test a target application</description>
+        <author>ZAP Dev Team</author>
+        <version>23</version>
+        <file>quickstart-release-23.zap</file>
+        <status>release</status>
+        <changes>Update for 2.7.0.&lt;br&gt;
+    Stop the quick scan if the session is changed.&lt;br&gt;
+    Added toolbar button to launch the latest browser chosen.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/quickstart-release-23.zap</url>
+        <hash>SHA1:34aed4c9a93220978799aff7002236a669c02b25</hash>
+        <date>2018-01-19</date>
+        <size>436181</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_quickstart>
+    <addon>replacer</addon>
+    <addon_replacer>
+        <name>Replacer</name>
+        <description>Easy way to replace strings in requests and responses.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>replacer-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Tweak help page.&lt;br&gt;
+    Ignore CFU HTTP messages.&lt;br&gt;
+    Allow to (explicitly) select Token Generator messages.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/replacer-beta-6.zap</url>
+        <hash>SHA1:94d43eee92dbbcf7854f64dd60c713c1a580e5ba</hash>
+        <date>2018-06-12</date>
+        <size>330710</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_replacer>
     <addon>requester</addon>
     <addon_requester>
         <name>Requester</name>
@@ -1440,7 +1083,21 @@
         <size>55741</size>
         <not-before-version>2.4.2</not-before-version>
     </addon_requester>
-
+    <addon>reveal</addon>
+    <addon_reveal>
+        <name>Reveal</name>
+        <description>Show hidden fields and enable disabled fields</description>
+        <author>ZAP Dev Team</author>
+        <version>2</version>
+        <file>reveal-release-2.zap</file>
+        <status>release</status>
+        <changes>Code changes and API documentation.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/reveal-release-2.zap</url>
+        <hash>SHA1:caec390697cdc2c82945371e80901af05cc2bfbc</hash>
+        <date>2017-11-27</date>
+        <size>230262</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_reveal>
     <addon>revisit</addon>
     <addon_revisit>
         <name>Revisit</name>
@@ -1457,7 +1114,6 @@
         <size>289297</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_revisit>
-
     <addon>saml</addon>
     <addon_saml>
         <name>SAML Extension</name>
@@ -1474,7 +1130,69 @@
         <size>997659</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_saml>
-
+    <addon>saverawmessage</addon>
+    <addon_saverawmessage>
+        <name>Save Raw Message</name>
+        <description>Allows to save content of HTTP messages as binary</description>
+        <author>ZAP Dev Team</author>
+        <version>4</version>
+        <file>saverawmessage-release-4.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/saverawmessage-release-4.zap</url>
+        <hash>SHA1:df600792159042a452e3e9215d9b89b21417bf88</hash>
+        <date>2017-11-27</date>
+        <size>27756</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_saverawmessage>
+    <addon>savexmlmessage</addon>
+    <addon_savexmlmessage>
+        <name>Save XML Message</name>
+        <description>Allows to save content of HTTP messages as XML</description>
+        <author>thatsn0tmysite</author>
+        <version>0.0.1</version>
+        <file>savexmlmessage-alpha-0.0.1.zap</file>
+        <status>alpha</status>
+        <changes>Initial release.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/savexmlmessage-alpha-0.0.1.zap</url>
+        <hash>SHA1:5a819610819e4edc227df5da4dac3c886f2b2d29</hash>
+        <date>2018-05-30</date>
+        <size>12873</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_savexmlmessage>
+    <addon>scripts</addon>
+    <addon_scripts>
+        <name>Script Console</name>
+        <description>Supports all JSR 223 scripting languages</description>
+        <author>ZAP Dev Team</author>
+        <version>24</version>
+        <file>scripts-beta-24.zap</file>
+        <status>beta</status>
+        <changes>Fix GUI freeze on script addition/removal through the API (Issue 4302).&lt;br&gt;
+    Prompt for a charset when failed to read the script file (Issue 3383).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/scripts-beta-24.zap</url>
+        <hash>SHA1:63295325786e27ee0d5920bb46656eda7ea1f514</hash>
+        <info>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</info>
+        <date>2018-01-25</date>
+        <size>639756</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_scripts>
+    <addon>selenium</addon>
+    <addon_selenium>
+        <name>Selenium</name>
+        <description>WebDriver provider and includes HtmlUnit browser</description>
+        <author>ZAP Dev Team</author>
+        <version>13</version>
+        <semver>2.0.0</semver>
+        <file>selenium-release-13.zap</file>
+        <status>release</status>
+        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/selenium-release-13.zap</url>
+        <hash>SHA1:27805e3b31a189d0377d359d0c9551dc820adde0</hash>
+        <date>2017-11-27</date>
+        <size>22796677</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_selenium>
     <addon>sequence</addon>
     <addon_sequence>
         <name>Sequence</name>
@@ -1497,7 +1215,6 @@
             </addons>
         </dependencies>
     </addon_sequence>
-
     <addon>soap</addon>
     <addon_soap>
         <name>SOAP Scanner</name>
@@ -1513,7 +1230,45 @@
         <size>7471507</size>
         <not-before-version>2.5.0</not-before-version>
     </addon_soap>
-
+    <addon>spiderAjax</addon>
+    <addon_spiderAjax>
+        <name>Ajax Spider</name>
+        <description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
+        <author>ZAP Dev Team</author>
+        <version>21</version>
+        <file>spiderAjax-release-21.zap</file>
+        <status>release</status>
+        <changes>Reset API scan also when in daemon mode (Issue 4163).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/spiderAjax-release-21.zap</url>
+        <hash>SHA1:92f5a3ecded1d5e0f3b889b07656f5ec8414ada0</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</info>
+        <date>2018-01-19</date>
+        <size>2597145</size>
+        <not-before-version>2.7.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>2.*</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_spiderAjax>
+    <addon>sqliplugin</addon>
+    <addon_sqliplugin>
+        <name>Advanced SQLInjection Scanner</name>
+        <description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
+        <author>Andrea Pompili (Yhawke)</author>
+        <version>12</version>
+        <file>sqliplugin-beta-12.zap</file>
+        <status>beta</status>
+        <changes>Minor code changes.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/sqliplugin-beta-12.zap</url>
+        <hash>SHA1:7661c839f8ab0fa731d6629de1b7526b706d6bb6</hash>
+        <date>2017-11-27</date>
+        <size>119265</size>
+        <not-before-version>2.4.1</not-before-version>
+    </addon_sqliplugin>
     <addon>sse</addon>
     <addon_sse>
         <name>Server-Sent Events</name>
@@ -1528,7 +1283,37 @@
         <size>333669</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_sse>
-
+    <addon>svndigger</addon>
+    <addon_svndigger>
+        <name>SVN Digger files</name>
+        <description>SVN Digger files which can be used with ZAP forced browsing</description>
+        <author>ZAP Dev Team</author>
+        <version>3</version>
+        <file>svndigger-beta-3.zap</file>
+        <status>beta</status>
+        <changes>Updated for ZAP 2.4</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/svndigger-beta-3.zap</url>
+        <hash>SHA1:8c7187180ed48466d6829e39469cc3d0915b1cbf</hash>
+        <info>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</info>
+        <date>2017-11-27</date>
+        <size>615459</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_svndigger>
+    <addon>tips</addon>
+    <addon_tips>
+        <name>Tips and Tricks</name>
+        <description>Display ZAP Tips and Tricks</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>tips-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Updated for 2.7.0.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tips-beta-6.zap</url>
+        <hash>SHA1:b6a560a292fa21b867a5c2385bfab0afcdfe0cd5</hash>
+        <date>2017-11-27</date>
+        <size>517219</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_tips>
     <addon>tlsdebug</addon>
     <addon_tlsdebug>
         <name>TLS Debug</name>
@@ -1544,7 +1329,42 @@
         <size>234482</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_tlsdebug>
-
+    <addon>tokengen</addon>
+    <addon_tokengen>
+        <name>Token generation and analysis</name>
+        <description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
+        <author>ZAP Dev Team</author>
+        <version>12</version>
+        <file>tokengen-beta-12.zap</file>
+        <status>beta</status>
+        <changes>Stop the test and clear the panel on session changes.&lt;br&gt;
+    Respect the current mode and react to changes.&lt;br&gt;
+    Inform of running test (e.g. on session change, add-on uninstall).&lt;br&gt;
+    Allow to configure the number of threads.&lt;br&gt;
+    Allow to delay the requests.&lt;br&gt;
+    Update minimum ZAP version to 2.6.0.&lt;br&gt;
+    Deletes the cookie in question before sending the request.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tokengen-beta-12.zap</url>
+        <hash>SHA1:71bb8a5bc15fe725b5ba38939559696589782583</hash>
+        <date>2018-05-17</date>
+        <size>323564</size>
+        <not-before-version>2.6.0</not-before-version>
+    </addon_tokengen>
+    <addon>treetools</addon>
+    <addon_treetools>
+        <name>TreeTools</name>
+        <description>Tools to add functionality to the tree view.</description>
+        <author>Carl Sampson</author>
+        <version>7</version>
+        <file>treetools-beta-7.zap</file>
+        <status>beta</status>
+        <changes>Code changes for Java 9 (Issue 2602)</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/treetools-beta-7.zap</url>
+        <hash>SHA1:38fbc4d4e22c0da73a4048522d250fa4ac89bdab</hash>
+        <date>2017-11-27</date>
+        <size>18821</size>
+        <not-before-version>2.4.0</not-before-version>
+    </addon_treetools>
     <addon>viewstate</addon>
     <addon_viewstate>
         <name>ViewState</name>
@@ -1559,7 +1379,6 @@
         <size>43907</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_viewstate>
-
     <addon>vulncheck</addon>
     <addon_vulncheck>
         <name>VulnCheck Extension</name>
@@ -1575,7 +1394,6 @@
         <size>35553</size>
         <not-before-version>2.4.0</not-before-version>
     </addon_vulncheck>
-
     <addon>wappalyzer</addon>
     <addon_wappalyzer>
         <name>Wappalyzer - Technology Detection</name>
@@ -1592,5 +1410,96 @@
         <size>1655510</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_wappalyzer>
-
+    <addon>webdriverlinux</addon>
+    <addon_webdriverlinux>
+        <name>Linux WebDrivers</name>
+        <description>Linux WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdriverlinux-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverlinux-beta-6.zap</url>
+        <hash>SHA1:ff062a3bc9869880d41f3e20587a388a403a8af9</hash>
+        <date>2018-06-11</date>
+        <size>9249857</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdriverlinux>
+    <addon>webdrivermacos</addon>
+    <addon_webdrivermacos>
+        <name>MacOS WebDrivers</name>
+        <description>MacOS WebDrivers for Firefox and Chrome.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdrivermacos-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdrivermacos-beta-6.zap</url>
+        <hash>SHA1:ce59ca4b71b776c3a9d8825a65fe613edf45f897</hash>
+        <date>2018-06-11</date>
+        <size>7228885</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdrivermacos>
+    <addon>webdriverwindows</addon>
+    <addon_webdriverwindows>
+        <name>Windows WebDrivers</name>
+        <description>Windows WebDrivers for Firefox, Chrome and IE.</description>
+        <author>ZAP Dev Team</author>
+        <version>6</version>
+        <file>webdriverwindows-beta-6.zap</file>
+        <status>beta</status>
+        <changes>Update ChromeDriver to 2.40&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/webdriverwindows-beta-6.zap</url>
+        <hash>SHA1:7fa7c1dbb6812031c52c85e8de4767671921e2e0</hash>
+        <date>2018-06-11</date>
+        <size>10943223</size>
+        <not-before-version>2.5.0</not-before-version>
+    </addon_webdriverwindows>
+    <addon>websocket</addon>
+    <addon_websocket>
+        <name>WebSockets</name>
+        <description>Allows you to inspect WebSocket communication.</description>
+        <author>ZAP Dev Team</author>
+        <version>16</version>
+        <file>websocket-release-16.zap</file>
+        <status>release</status>
+        <changes>Tweak About help page.&lt;br&gt;
+    Remove event consumers when the channel is closed.&lt;br&gt;
+    Don't enable the sender scripts by default.&lt;br&gt;
+    Fix send of CLOSE messages with message editor (Issue 4657).&lt;br&gt;
+    Add missing error message.&lt;br&gt;
+    Fix removal of pop up menu items.&lt;br&gt;
+    Allow to filter by payload in WebSocket tab (Issue 1382).&lt;br&gt;
+    Show string representation of binary payloads in WebSocket tab and message panels.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/websocket-release-16.zap</url>
+        <hash>SHA1:6cf3f4d5d7d12813f34e09339d90bf4353d16ed3</hash>
+        <date>2018-06-05</date>
+        <size>928242</size>
+        <not-before-version>2.7.0</not-before-version>
+    </addon_websocket>
+    <addon>zest</addon>
+    <addon_zest>
+        <name>Zest - Graphical Security Scripting Language</name>
+        <description>A graphical security scripting language, ZAPs macro language on steroids</description>
+        <author>ZAP Dev Team</author>
+        <version>27</version>
+        <file>zest-beta-27.zap</file>
+        <status>beta</status>
+        <changes>Fix exception when editing Action - Script with unsaved scripts.&lt;br&gt;
+    Allow to select more HTTP methods in Zest Request dialogue.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/zest-beta-27.zap</url>
+        <hash>SHA1:aa66b3e03f924265f011044747b54de967cecde4</hash>
+        <info>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</info>
+        <date>2018-01-19</date>
+        <size>2106780</size>
+        <not-before-version>2.7.0</not-before-version>
+        <dependencies>
+            <addons>
+                <addon>
+                    <id>selenium</id>
+                    <semver>&gt;=2.0.0 &amp; &lt;3.0.0</semver>
+                </addon>
+            </addons>
+        </dependencies>
+    </addon_zest>
 </ZAP>

--- a/ZapVersions.xml
+++ b/ZapVersions.xml
@@ -1,34 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
-	<core>
-		<version>2.7.0</version>
-		<daily-version>D-2018-07-02</daily-version>
-		<daily>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
-			<file>ZAP_WEEKLY_D-2018-07-02.zip</file>
-			<hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
-			<size>264384154</size>
-		</daily>
-		<windows>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
-			<file>ZAP_2_7_0_windows.exe</file>
-			<hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
-			<size>116391936</size>
-		</windows>
-		<linux>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
-			<file>ZAP_2.7.0_Linux.tar.gz</file>
-			<hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
-			<size>130903023</size>
-		</linux>
-		<mac>
-			<url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
-			<file>ZAP_2.7.0.dmg</file>
-			<hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
-			<size>188102126</size>
-		</mac>
-		<relnotes>
-			Bug fix and enhancement release.
-		</relnotes>
-		<relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
-	</core>
+    <core>
+        <version>2.7.0</version>
+        <daily-version>D-2018-07-02</daily-version>
+        <daily>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/w2018-07-02/ZAP_WEEKLY_D-2018-07-02.zip</url>
+            <file>ZAP_WEEKLY_D-2018-07-02.zip</file>
+            <hash>SHA1:085cada49685d9447cc44e9d502473ee99b0a067</hash>
+            <size>264384154</size>
+        </daily>
+        <windows>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2_7_0_windows.exe</url>
+            <file>ZAP_2_7_0_windows.exe</file>
+            <hash>SHA1:ed0b6021be4ba4099297d7cd7b316921a365e8e9</hash>
+            <size>116391936</size>
+        </windows>
+        <linux>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0_Linux.tar.gz</url>
+            <file>ZAP_2.7.0_Linux.tar.gz</file>
+            <hash>SHA1:35f15d04213f34cdd531125cc4d19c733e7cec5a</hash>
+            <size>130903023</size>
+        </linux>
+        <mac>
+            <url>https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAP_2.7.0.dmg</url>
+            <file>ZAP_2.7.0.dmg</file>
+            <hash>SHA1:ff027ae952e7a17a9dd1fcec93c5ff3799d56971</hash>
+            <size>188102126</size>
+        </mac>
+        <relnotes>Bug fix and enhancement release.</relnotes>
+        <relnotes-url>https://github.com/zaproxy/zap-core-help/wiki/HelpReleases2_7_0</relnotes-url>
+    </core>
 </ZAP>


### PR DESCRIPTION
Use same character for indentation (spaces instead of mixed spaces and
tabs) and sort add-ons by ID.
This makes it more consistent and reliable when adding or updating
add-on entries programmatically (e.g. build tasks).