### PR TITLE
Remove unnecessary Crowdin configuration entry

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -77,13 +77,6 @@
                     exportpattern="%file_name%_%locale_with_underscore%.%file_extension%">
 				</ccinclude>
 			</ccfiles>
-			<!-- zaproxy project core add-ons -->
-			<ccfiles basedir="${src}/org/zaproxy/zap/extension/" exportpatternprefix="/zaproxy/add-ons/">
-				<!-- core-addons/ -->
-				<ccinclude source="*/resources/Messages.properties" 
-                    crowdinpath="/core/*/%original_file_name%"
-                    exportpattern="*/resources/%file_name%_%locale_with_underscore%.%file_extension%" />
-			</ccfiles>
 			<!-- zap-extensions project -->
 			<!-- alpha extensions -->
 			<ccfiles basedir="${zap.extensions.alpha.dir}/src/org/zaproxy/zap/extension/" 


### PR DESCRIPTION
Remove configuration for Messages.properties in core extensions, that's
no longer used/needed, all core extensions use the same file.