### PR TITLE
Add Error Prone to build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,18 @@
+buildscript {
+    repositories {
+        maven { url = uri("https://plugins.gradle.org/m2/") }
+    }
+    dependencies {
+        classpath(if (JavaVersion.current() == JavaVersion.VERSION_1_8) "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16" else "net.ltgt.gradle:gradle-errorprone-javacplugin-plugin:0.3")
+    }
+}
+
 plugins {
     java
     id("com.diffplug.gradle.spotless") version "3.13.0"
 }
+
+apply(plugin = if (JavaVersion.current() == JavaVersion.VERSION_1_8) "net.ltgt.errorprone" else "net.ltgt.errorprone-javacplugin")
 
 tasks {
     "wrapper"(Wrapper::class) {

--- a/src/main/java/org/zaproxy/admin/CheckLatestReleaseNotes.java
+++ b/src/main/java/org/zaproxy/admin/CheckLatestReleaseNotes.java
@@ -21,9 +21,10 @@ package org.zaproxy.admin;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeMap;
@@ -40,14 +41,14 @@ public class CheckLatestReleaseNotes {
 
     private static Set<Integer> getIssues(File f) throws IOException {
         Set<Integer> set = new HashSet<Integer>();
-        try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
+        try (BufferedReader reader = Files.newBufferedReader(f.toPath(), StandardCharsets.UTF_8)) {
             while (true) {
                 String line = reader.readLine();
                 if (line == null) {
                     break;
                 }
                 if (line.startsWith("<li>Issue ")) {
-                    String[] split = line.split(" ");
+                    String[] split = line.split(" ", 0);
                     set.add(Integer.parseInt(split[1]));
                 }
             }

--- a/src/main/java/org/zaproxy/admin/CountDownloads.java
+++ b/src/main/java/org/zaproxy/admin/CountDownloads.java
@@ -19,9 +19,6 @@
  */
 package org.zaproxy.admin;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URL;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -39,25 +36,6 @@ public class CountDownloads {
     private static final String TAG_URL =
             "https://api.github.com/repos/zaproxy/zaproxy/releases/tags/";
 
-    private static String readUrl(String urlString) throws Exception {
-        BufferedReader reader = null;
-        try {
-            URL url = new URL(urlString);
-            reader = new BufferedReader(new InputStreamReader(url.openStream()));
-            StringBuffer buffer = new StringBuffer();
-            int read;
-            char[] chars = new char[1024];
-            while ((read = reader.read(chars)) != -1) {
-                buffer.append(chars, 0, read);
-            }
-            return buffer.toString();
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
-        }
-    }
-
     private static void parseRelease(JSONObject tag) throws Exception {
         String tagName = tag.getString("tag_name");
         System.out.println("Tag " + tagName);
@@ -74,34 +52,29 @@ public class CountDownloads {
     }
 
     private static JSONObject getRelease(String tag) throws Exception {
-        return JSONObject.fromObject(readUrl(TAG_URL + tag));
+        return JSONObject.fromObject(Utils.readUrl(TAG_URL + tag));
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         // Loop through tags, print names
-        try {
-            String jsonStr = readUrl(RELEASES_URL);
+        String jsonStr = Utils.readUrl(RELEASES_URL);
 
-            JSONArray json = JSONArray.fromObject(jsonStr);
+        JSONArray json = JSONArray.fromObject(jsonStr);
 
-            if (json.size() >= 100) {
-                System.out.println(
-                        "WARNING: 100 tags returned - will need to implement paging to get the rest!");
-            }
-
-            for (int i = 0; i < json.size(); i++) {
-                parseRelease(json.getJSONObject(i));
-            }
-
-            // Explicitly request the most recent main releases
-            parseRelease(getRelease("2.7.0"));
-            parseRelease(getRelease("2.6.0"));
-            parseRelease(getRelease("2.5.0"));
-            parseRelease(getRelease("2.4.3"));
-            parseRelease(getRelease("2.4.2"));
-
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (json.size() >= 100) {
+            System.out.println(
+                    "WARNING: 100 tags returned - will need to implement paging to get the rest!");
         }
+
+        for (int i = 0; i < json.size(); i++) {
+            parseRelease(json.getJSONObject(i));
+        }
+
+        // Explicitly request the most recent main releases
+        parseRelease(getRelease("2.7.0"));
+        parseRelease(getRelease("2.6.0"));
+        parseRelease(getRelease("2.5.0"));
+        parseRelease(getRelease("2.4.3"));
+        parseRelease(getRelease("2.4.2"));
     }
 }

--- a/src/main/java/org/zaproxy/admin/GenerateReleaseNotes.java
+++ b/src/main/java/org/zaproxy/admin/GenerateReleaseNotes.java
@@ -19,9 +19,6 @@
  */
 package org.zaproxy.admin;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,134 +43,112 @@ public class GenerateReleaseNotes {
     private static final String ISSUE_BASE_URL =
             "https://api.github.com/repos/zaproxy/zaproxy/issues?state=closed&per_page=100&since=";
 
-    private static String readUrl(String urlString) throws Exception {
-        BufferedReader reader = null;
-        try {
-            URL url = new URL(urlString);
-            reader = new BufferedReader(new InputStreamReader(url.openStream()));
-            StringBuffer buffer = new StringBuffer();
-            int read;
-            char[] chars = new char[1024];
-            while ((read = reader.read(chars)) != -1) buffer.append(chars, 0, read);
-
-            return buffer.toString();
-        } finally {
-            if (reader != null) reader.close();
-        }
-    }
-
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         // For now hardcoding variables - should make these parameters at some point ;)
         String dateSince = "2015-12-05T00:00:00Z";
-        try {
-            Map<Integer, String> devIssuesMap = new HashMap<Integer, String>();
-            Map<Integer, String> bugIssuesMap = new HashMap<Integer, String>();
-            Map<Integer, String> unkIssuesMap = new HashMap<Integer, String>();
-            Map<Integer, String> issueTagsMap = new HashMap<Integer, String>();
+        Map<Integer, String> devIssuesMap = new HashMap<Integer, String>();
+        Map<Integer, String> bugIssuesMap = new HashMap<Integer, String>();
+        Map<Integer, String> unkIssuesMap = new HashMap<Integer, String>();
+        Map<Integer, String> issueTagsMap = new HashMap<Integer, String>();
 
-            int page = 0;
-            while (true) {
-                page++;
-                String issueStr = readUrl(ISSUE_BASE_URL + dateSince + "&page=" + page);
+        int page = 0;
+        while (true) {
+            page++;
+            String issueStr = Utils.readUrl(ISSUE_BASE_URL + dateSince + "&page=" + page);
 
-                JSONArray json = JSONArray.fromObject(issueStr);
+            JSONArray json = JSONArray.fromObject(issueStr);
 
-                for (int i = 0; i < json.size(); i++) {
-                    IssueType issueType = IssueType.unk;
-                    JSONObject issue = json.getJSONObject(i);
-                    JSONArray labels = issue.getJSONArray("labels");
-                    StringBuilder sb = new StringBuilder();
-                    for (int j = 0; j < labels.size(); j++) {
-                        String tag = labels.getJSONObject(j).getString("name");
-                        sb.append(tag);
-                        sb.append(" ");
+            for (int i = 0; i < json.size(); i++) {
+                IssueType issueType = IssueType.unk;
+                JSONObject issue = json.getJSONObject(i);
+                JSONArray labels = issue.getJSONArray("labels");
+                StringBuilder sb = new StringBuilder();
+                for (int j = 0; j < labels.size(); j++) {
+                    String tag = labels.getJSONObject(j).getString("name");
+                    sb.append(tag);
+                    sb.append(" ");
 
-                        if (tag.equalsIgnoreCase("development")
-                                || tag.equalsIgnoreCase("enhancement")
-                                || tag.equalsIgnoreCase("Type-enhancement")) {
-                            issueType = IssueType.dev;
-                            // Carry on in case its got another 'overiding' tag
-                        }
-                        if (tag.equalsIgnoreCase("bug") || tag.equalsIgnoreCase("Type-defect")) {
-                            issueType = IssueType.bug;
-                            // Carry on in case its got another 'overiding' tag
-                        }
-                        if (tag.equalsIgnoreCase("invalid")
-                                || tag.equalsIgnoreCase("duplicate")
-                                || tag.equalsIgnoreCase("historic")
-                                || tag.equalsIgnoreCase("wontfix")
-                                || tag.equalsIgnoreCase("minor")
-                                || tag.equalsIgnoreCase("add-on")
-                                || tag.equalsIgnoreCase("Type-Other")
-                                || tag.equalsIgnoreCase("Type-review")
-                                || tag.equalsIgnoreCase("Type-task")
-                                || tag.equalsIgnoreCase("competition")
-                                || tag.equalsIgnoreCase("InsufficientEvidence")
-                                || tag.equalsIgnoreCase("question")
-                                || tag.equalsIgnoreCase("weekly")) {
-                            issueType = IssueType.ignore;
-                            break;
-                        }
+                    if (tag.equalsIgnoreCase("development")
+                            || tag.equalsIgnoreCase("enhancement")
+                            || tag.equalsIgnoreCase("Type-enhancement")) {
+                        issueType = IssueType.dev;
+                        // Carry on in case its got another 'overiding' tag
                     }
-                    issueTagsMap.put(issue.getInt("number"), sb.toString());
-
-                    switch (issueType) {
-                        case dev:
-                            devIssuesMap.put(issue.getInt("number"), issue.getString("title"));
-                            break;
-                        case bug:
-                            bugIssuesMap.put(issue.getInt("number"), issue.getString("title"));
-                            break;
-                        case unk:
-                            unkIssuesMap.put(issue.getInt("number"), issue.getString("title"));
-                            break;
-                        case ignore:
-                            break;
+                    if (tag.equalsIgnoreCase("bug") || tag.equalsIgnoreCase("Type-defect")) {
+                        issueType = IssueType.bug;
+                        // Carry on in case its got another 'overiding' tag
+                    }
+                    if (tag.equalsIgnoreCase("invalid")
+                            || tag.equalsIgnoreCase("duplicate")
+                            || tag.equalsIgnoreCase("historic")
+                            || tag.equalsIgnoreCase("wontfix")
+                            || tag.equalsIgnoreCase("minor")
+                            || tag.equalsIgnoreCase("add-on")
+                            || tag.equalsIgnoreCase("Type-Other")
+                            || tag.equalsIgnoreCase("Type-review")
+                            || tag.equalsIgnoreCase("Type-task")
+                            || tag.equalsIgnoreCase("competition")
+                            || tag.equalsIgnoreCase("InsufficientEvidence")
+                            || tag.equalsIgnoreCase("question")
+                            || tag.equalsIgnoreCase("weekly")) {
+                        issueType = IssueType.ignore;
+                        break;
                     }
                 }
-                if (json.size() < 100) {
-                    break;
+                issueTagsMap.put(issue.getInt("number"), sb.toString());
+
+                switch (issueType) {
+                    case dev:
+                        devIssuesMap.put(issue.getInt("number"), issue.getString("title"));
+                        break;
+                    case bug:
+                        bugIssuesMap.put(issue.getInt("number"), issue.getString("title"));
+                        break;
+                    case unk:
+                        unkIssuesMap.put(issue.getInt("number"), issue.getString("title"));
+                        break;
+                    case ignore:
+                        break;
                 }
             }
-
-            System.out.println("<H2>Enhancements:</H2>");
-            System.out.println("<ul>");
-            Object[] devIssues = devIssuesMap.keySet().toArray();
-            Arrays.sort(devIssues);
-            for (Object key : devIssues) {
-                System.out.println("<li>Issue " + key + " : " + devIssuesMap.get(key) + "</li>");
+            if (json.size() < 100) {
+                break;
             }
-            System.out.println("</ul>");
+        }
+
+        System.out.println("<H2>Enhancements:</H2>");
+        System.out.println("<ul>");
+        Object[] devIssues = devIssuesMap.keySet().toArray();
+        Arrays.sort(devIssues);
+        for (Object key : devIssues) {
+            System.out.println("<li>Issue " + key + " : " + devIssuesMap.get(key) + "</li>");
+        }
+        System.out.println("</ul>");
+        System.out.println("");
+
+        System.out.println("<H2>Bug fixes:</H2>");
+        System.out.println("<ul>");
+        Object[] bugIssues = bugIssuesMap.keySet().toArray();
+        Arrays.sort(bugIssues);
+        for (Object key : bugIssues) {
+            System.out.println("<li>Issue " + key + " : " + bugIssuesMap.get(key) + "</li>");
+        }
+        System.out.println("</ul>");
+        System.out.println("");
+
+        if (unkIssuesMap.size() > 0) {
+            System.out.println("Unclassified:");
             System.out.println("");
-
-            System.out.println("<H2>Bug fixes:</H2>");
-            System.out.println("<ul>");
-            Object[] bugIssues = bugIssuesMap.keySet().toArray();
-            Arrays.sort(bugIssues);
-            for (Object key : bugIssues) {
-                System.out.println("<li>Issue " + key + " : " + bugIssuesMap.get(key) + "</li>");
-            }
-            System.out.println("</ul>");
-            System.out.println("");
-
-            if (unkIssuesMap.size() > 0) {
-                System.out.println("Unclassified:");
-                System.out.println("");
-                Object[] unkIssues = unkIssuesMap.keySet().toArray();
-                Arrays.sort(unkIssues);
-                for (Object key : unkIssues) {
-                    System.out.println("Issue " + key + " : " + unkIssuesMap.get(key));
-                    System.out.println("\tLink: https://github.com/zaproxy/zaproxy/issues/" + key);
-                    String tags = issueTagsMap.get(key);
-                    if (tags != null && tags.length() > 0) {
-                        System.out.println("\tTags: " + issueTagsMap.get(key));
-                    }
+            Object[] unkIssues = unkIssuesMap.keySet().toArray();
+            Arrays.sort(unkIssues);
+            for (Object key : unkIssues) {
+                System.out.println("Issue " + key + " : " + unkIssuesMap.get(key));
+                System.out.println("\tLink: https://github.com/zaproxy/zaproxy/issues/" + key);
+                String tags = issueTagsMap.get(key);
+                if (tags != null && tags.length() > 0) {
+                    System.out.println("\tTags: " + issueTagsMap.get(key));
                 }
             }
-
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/org/zaproxy/admin/HelpGenerator.java
+++ b/src/main/java/org/zaproxy/admin/HelpGenerator.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -135,7 +136,8 @@ public class HelpGenerator {
     }
 
     public static void main(String[] args) throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        BufferedReader in =
+                new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
         String dir = null;
         do {
             String status = null;

--- a/src/main/java/org/zaproxy/admin/Utils.java
+++ b/src/main/java/org/zaproxy/admin/Utils.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.admin;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/** Utilities for common tasks. */
+public class Utils {
+
+    private Utils() {
+        // Utility class.
+    }
+
+    public static String readUrl(String urlString) throws IOException {
+        try (BufferedReader reader =
+                new BufferedReader(
+                        new InputStreamReader(
+                                new URL(urlString).openStream(), StandardCharsets.UTF_8))) {
+            StringBuilder builder = new StringBuilder();
+            int read;
+            char[] chars = new char[1024];
+            while ((read = reader.read(chars)) != -1) {
+                builder.append(chars, 0, read);
+            }
+            return builder.toString();
+        }
+    }
+}


### PR DESCRIPTION
Change build to use Error Prone when compiling.
Address warnings reported by Error Prone:
 - Extract a utility class to read the a response from a URL, also,
 address warnings, by not relying on default charset when reading the
 response (DefaultCharset) and not using StringBuffer (JdkObsolete).
 - Change CheckLatestReleaseNotes to not rely on default charset when
 reading the release pages (DefaultCharset), they are in UTF-8, and
 change to split the issues with a limit (StringSplitter).
 - Change CountDownloads to use the extracted class and to not catch and
 print the exception in the main method, let it be handled  by the
 caller (e.g. build) (CatchAndPrintStackTrace).
 - Address previous warnings also in GenerateReleaseNotes.
 - Change HelpGenerator to explicitly use default charset when reading
 the input from command line (DefaultCharset).