### PR TITLE
Release new versions of alpha add-ons

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -1083,15 +1083,18 @@
         <name>Requester</name>
         <description>Request numbered panel.</description>
         <author>Surikato</author>
-        <version>2</version>
-        <file>requester-alpha-2.zap</file>
+        <version>3</version>
+        <file>requester-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/requester-alpha-2.zap</url>
-        <hash>SHA1:143b35993587ba84751881c2440bf5a923974583</hash>
-        <date>2017-11-28</date>
-        <size>55741</size>
-        <not-before-version>2.4.2</not-before-version>
+        <changes>Maintenance changes.&lt;br&gt;
+    Change default accelerator for Requester tab.&lt;br&gt;
+    Dynamically unload the add-on.&lt;br&gt;
+    Ensure use of title caps (Issue 2000).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/requester-alpha-3.zap</url>
+        <hash>SHA1:bd78559ccd89a94c2f0bc32dc09877a2b83b857e</hash>
+        <date>2018-10-15</date>
+        <size>58164</size>
+        <not-before-version>2.7.0</not-before-version>
     </addon_requester>
     <addon>reveal</addon>
     <addon_reveal>
@@ -1330,15 +1333,16 @@
         <name>TLS Debug</name>
         <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
         <author>P.M.J. Roth</author>
-        <version>2</version>
-        <file>tlsdebug-alpha-2.zap</file>
+        <version>3</version>
+        <file>tlsdebug-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tlsdebug-alpha-2.zap</url>
-        <hash>SHA1:eae19e915821482890f46763fc0b2397dcb58002</hash>
-        <date>2017-11-28</date>
-        <size>234482</size>
-        <not-before-version>2.4.0</not-before-version>
+        <changes>Update minimum ZAP version to 2.5.0.&lt;br&gt;
+    Change default accelerator for TLS Debug tab.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tlsdebug-alpha-3.zap</url>
+        <hash>SHA1:1cbbbeca9e1681c968cddf612c7938c0dd6e1181</hash>
+        <date>2018-10-15</date>
+        <size>244231</size>
+        <not-before-version>2.5.0</not-before-version>
     </addon_tlsdebug>
     <addon>tokengen</addon>
     <addon_tokengen>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -1083,15 +1083,18 @@
         <name>Requester</name>
         <description>Request numbered panel.</description>
         <author>Surikato</author>
-        <version>2</version>
-        <file>requester-alpha-2.zap</file>
+        <version>3</version>
+        <file>requester-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/requester-alpha-2.zap</url>
-        <hash>SHA1:143b35993587ba84751881c2440bf5a923974583</hash>
-        <date>2017-11-28</date>
-        <size>55741</size>
-        <not-before-version>2.4.2</not-before-version>
+        <changes>Maintenance changes.&lt;br&gt;
+    Change default accelerator for Requester tab.&lt;br&gt;
+    Dynamically unload the add-on.&lt;br&gt;
+    Ensure use of title caps (Issue 2000).&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/requester-alpha-3.zap</url>
+        <hash>SHA1:bd78559ccd89a94c2f0bc32dc09877a2b83b857e</hash>
+        <date>2018-10-15</date>
+        <size>58164</size>
+        <not-before-version>2.7.0</not-before-version>
     </addon_requester>
     <addon>reveal</addon>
     <addon_reveal>
@@ -1330,15 +1333,16 @@
         <name>TLS Debug</name>
         <description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
         <author>P.M.J. Roth</author>
-        <version>2</version>
-        <file>tlsdebug-alpha-2.zap</file>
+        <version>3</version>
+        <file>tlsdebug-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Code changes for Java 9 (Issue 2602).&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tlsdebug-alpha-2.zap</url>
-        <hash>SHA1:eae19e915821482890f46763fc0b2397dcb58002</hash>
-        <date>2017-11-28</date>
-        <size>234482</size>
-        <not-before-version>2.4.0</not-before-version>
+        <changes>Update minimum ZAP version to 2.5.0.&lt;br&gt;
+    Change default accelerator for TLS Debug tab.&lt;br&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/tlsdebug-alpha-3.zap</url>
+        <hash>SHA1:1cbbbeca9e1681c968cddf612c7938c0dd6e1181</hash>
+        <date>2018-10-15</date>
+        <size>244231</size>
+        <not-before-version>2.5.0</not-before-version>
     </addon_tlsdebug>
     <addon>tokengen</addon>
     <addon_tokengen>


### PR DESCRIPTION
 - Requester version 3.
 - TLS Debug version 3.

---
Related to zaproxy/zaproxy#5056, with this release all add-ons in the marketplace have the status declared in the manifest.