### PR TITLE
Release JxBrowser add-ons

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -827,14 +827,18 @@
         <name>JxBrowser (core)</name>
         <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
         <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>jxbrowser-alpha-11.zap</file>
+        <version>12</version>
+        <file>jxbrowser-alpha-12.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowser-alpha-11.zap</url>
-        <hash>SHA1:37ee1d1f2073a8fe413e1282b4c731f95296dbcc</hash>
-        <date>2019-01-17</date>
-        <size>1501241</size>
+        <changes>
+    Update JxBrowser to 6.23.&lt;br>
+    Fix typo and tweak error message.&lt;br>
+    Log JxBrowser version on start up.&lt;br>
+    </changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowser-alpha-12.zap</url>
+        <hash>SHA1:d5788b4c7d46b962bbeff197a044477a8146f2a1</hash>
+        <date>2019-03-04</date>
+        <size>1505314</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_jxbrowser>
     <addon>jxbrowserlinux64</addon>
@@ -842,14 +846,14 @@
         <name>JxBrowser (Linux 64)</name>
         <description>An embedded browser based on Chromium, Linux 64 specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowserlinux64-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowserlinux64-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserlinux64-alpha-9.zap</url>
-        <hash>SHA1:13ce047bd5a1da09e8d24ce7fd541310a6ba1d59</hash>
-        <date>2019-01-17</date>
-        <size>59176580</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserlinux64-alpha-10.zap</url>
+        <hash>SHA1:2d088b7b08c3ee3643e809c037ff0e32626f1c73</hash>
+        <date>2019-03-04</date>
+        <size>62868652</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -864,14 +868,14 @@
         <name>JxBrowser (Mac OS)</name>
         <description>An embedded browser based on Chromium, Mac OS specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowsermacos-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowsermacos-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowsermacos-alpha-9.zap</url>
-        <hash>SHA1:63a934be3326a927d45dc983378b9f40d5243ea2</hash>
-        <date>2019-01-17</date>
-        <size>64439789</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowsermacos-alpha-10.zap</url>
+        <hash>SHA1:a0e396bfef4f55c1d6e28b9bea43a9690638f340</hash>
+        <date>2019-03-04</date>
+        <size>69021727</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -886,14 +890,14 @@
         <name>JxBrowser (Windows)</name>
         <description>An embedded browser based on Chromium, Windows specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowserwindows-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowserwindows-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows-alpha-9.zap</url>
-        <hash>SHA1:ac64957cca8ba49593ef3f22bd58c6c54cea269c</hash>
-        <date>2019-01-17</date>
-        <size>47079838</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows-alpha-10.zap</url>
+        <hash>SHA1:6536db2f3d6ba3e85980defaedb3967f5f214c85</hash>
+        <date>2019-03-04</date>
+        <size>50055150</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -908,14 +912,14 @@
         <name>JxBrowser (Windows 64)</name>
         <description>An embedded browser based on Chromium, Windows 64bits specific</description>
         <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowserwindows64-alpha-2.zap</file>
+        <version>3</version>
+        <file>jxbrowserwindows64-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows64-alpha-2.zap</url>
-        <hash>SHA1:90e7d01bdcb2d9da63f7c817c6e2202713d95d40</hash>
-        <date>2019-01-17</date>
-        <size>48951949</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows64-alpha-3.zap</url>
+        <hash>SHA1:2fc849b4c4691b28c0ca33341f305d367de3aacf</hash>
+        <date>2019-03-04</date>
+        <size>51683249</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -872,14 +872,18 @@
         <name>JxBrowser (core)</name>
         <description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
         <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>jxbrowser-alpha-11.zap</file>
+        <version>12</version>
+        <file>jxbrowser-alpha-12.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowser-alpha-11.zap</url>
-        <hash>SHA1:37ee1d1f2073a8fe413e1282b4c731f95296dbcc</hash>
-        <date>2019-01-17</date>
-        <size>1501241</size>
+        <changes>
+    Update JxBrowser to 6.23.&lt;br>
+    Fix typo and tweak error message.&lt;br>
+    Log JxBrowser version on start up.&lt;br>
+    </changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowser-alpha-12.zap</url>
+        <hash>SHA1:d5788b4c7d46b962bbeff197a044477a8146f2a1</hash>
+        <date>2019-03-04</date>
+        <size>1505314</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_jxbrowser>
     <addon>jxbrowserlinux64</addon>
@@ -887,14 +891,14 @@
         <name>JxBrowser (Linux 64)</name>
         <description>An embedded browser based on Chromium, Linux 64 specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowserlinux64-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowserlinux64-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserlinux64-alpha-9.zap</url>
-        <hash>SHA1:13ce047bd5a1da09e8d24ce7fd541310a6ba1d59</hash>
-        <date>2019-01-17</date>
-        <size>59176580</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserlinux64-alpha-10.zap</url>
+        <hash>SHA1:2d088b7b08c3ee3643e809c037ff0e32626f1c73</hash>
+        <date>2019-03-04</date>
+        <size>62868652</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -909,14 +913,14 @@
         <name>JxBrowser (Mac OS)</name>
         <description>An embedded browser based on Chromium, Mac OS specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowsermacos-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowsermacos-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowsermacos-alpha-9.zap</url>
-        <hash>SHA1:63a934be3326a927d45dc983378b9f40d5243ea2</hash>
-        <date>2019-01-17</date>
-        <size>64439789</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowsermacos-alpha-10.zap</url>
+        <hash>SHA1:a0e396bfef4f55c1d6e28b9bea43a9690638f340</hash>
+        <date>2019-03-04</date>
+        <size>69021727</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -931,14 +935,14 @@
         <name>JxBrowser (Windows)</name>
         <description>An embedded browser based on Chromium, Windows specific</description>
         <author>ZAP Dev Team</author>
-        <version>9</version>
-        <file>jxbrowserwindows-alpha-9.zap</file>
+        <version>10</version>
+        <file>jxbrowserwindows-alpha-10.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows-alpha-9.zap</url>
-        <hash>SHA1:ac64957cca8ba49593ef3f22bd58c6c54cea269c</hash>
-        <date>2019-01-17</date>
-        <size>47079838</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows-alpha-10.zap</url>
+        <hash>SHA1:6536db2f3d6ba3e85980defaedb3967f5f214c85</hash>
+        <date>2019-03-04</date>
+        <size>50055150</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>
@@ -953,14 +957,14 @@
         <name>JxBrowser (Windows 64)</name>
         <description>An embedded browser based on Chromium, Windows 64bits specific</description>
         <author>ZAP Dev Team</author>
-        <version>2</version>
-        <file>jxbrowserwindows64-alpha-2.zap</file>
+        <version>3</version>
+        <file>jxbrowserwindows64-alpha-3.zap</file>
         <status>alpha</status>
-        <changes>Updated to JxBrowser 6.22.2</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows64-alpha-2.zap</url>
-        <hash>SHA1:90e7d01bdcb2d9da63f7c817c6e2202713d95d40</hash>
-        <date>2019-01-17</date>
-        <size>48951949</size>
+        <changes>Update JxBrowser to 6.23.</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/jxbrowserwindows64-alpha-3.zap</url>
+        <hash>SHA1:2fc849b4c4691b28c0ca33341f305d367de3aacf</hash>
+        <date>2019-03-04</date>
+        <size>51683249</size>
         <not-before-version>2.7.0</not-before-version>
         <dependencies>
             <addons>


### PR DESCRIPTION
 - JxBrowser (core) version 12;
 - JxBrowser (Linux 64) version 10;
 - JxBrowser (Mac OS) version 10;
 - JxBrowser (Windows) version 10;
 - JxBrowser (Windows 64) version 3.