### PR TITLE
soap: remove from marketplace

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -1258,21 +1258,6 @@
             </addons>
         </dependencies>
     </addon_sequence>
-    <addon>soap</addon>
-    <addon_soap>
-        <name>SOAP Scanner</name>
-        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
-        <author>Alberto (albertov91) + ZAP Core team</author>
-        <version>3</version>
-        <file>soap-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Added API, help and other minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/soap-alpha-3.zap</url>
-        <hash>SHA1:a2002b00a738f4dbc39091649912c5030f9bba7a</hash>
-        <date>2017-11-28</date>
-        <size>7471507</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_soap>
     <addon>spiderAjax</addon>
     <addon_spiderAjax>
         <name>Ajax Spider</name>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -1303,21 +1303,6 @@
             </addons>
         </dependencies>
     </addon_sequence>
-    <addon>soap</addon>
-    <addon_soap>
-        <name>SOAP Scanner</name>
-        <description>Imports and scans WSDL files containing SOAP endpoints.</description>
-        <author>Alberto (albertov91) + ZAP Core team</author>
-        <version>3</version>
-        <file>soap-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>Added API, help and other minor code changes.</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/soap-alpha-3.zap</url>
-        <hash>SHA1:a2002b00a738f4dbc39091649912c5030f9bba7a</hash>
-        <date>2017-11-28</date>
-        <size>7471507</size>
-        <not-before-version>2.5.0</not-before-version>
-    </addon_soap>
     <addon>spiderAjax</addon>
     <addon_spiderAjax>
         <name>Ajax Spider</name>


### PR DESCRIPTION
The SOAP Scanner add-on is not working correctly.

From zaproxy/zaproxy#4866.