### PR TITLE
Update for HttpsInfo v12 release

### DIFF
--- a/ZapVersions-2.7.xml
+++ b/ZapVersions-2.7.xml
@@ -723,14 +723,17 @@
         <name>HttpsInfo</name>
         <description>Displays HTTPS configuration information.</description>
         <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>httpsInfo-alpha-11.zap</file>
+        <version>12</version>
+        <file>httpsInfo-alpha-12.zap</file>
         <status>alpha</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/httpsInfo-alpha-11.zap</url>
-        <hash>SHA1:6476320580a364a208faa187e7df72356c90cfa4</hash>
-        <date>2017-11-28</date>
-        <size>5542543</size>
+        <changes>&lt;ul&gt;
+&lt;li&gt;New tabbed UI.&lt;/li&gt;
+&lt;li&gt;Update to DeepViolet 5.1.16.&lt;/li&gt;
+&lt;/ul&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/httpsInfo-v12/httpsInfo-alpha-12.zap</url>
+        <hash>SHA1:c9c44e815522b32f3870bae898ed4e76e9011207</hash>
+        <date>2019-04-26</date>
+        <size>7690429</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_httpsInfo>
     <addon>imagelocationscanner</addon>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -723,14 +723,17 @@
         <name>HttpsInfo</name>
         <description>Displays HTTPS configuration information.</description>
         <author>ZAP Dev Team</author>
-        <version>11</version>
-        <file>httpsInfo-alpha-11.zap</file>
+        <version>12</version>
+        <file>httpsInfo-alpha-12.zap</file>
         <status>alpha</status>
-        <changes>Updated for 2.7.0.&lt;br&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/2.7/httpsInfo-alpha-11.zap</url>
-        <hash>SHA1:6476320580a364a208faa187e7df72356c90cfa4</hash>
-        <date>2017-11-28</date>
-        <size>5542543</size>
+        <changes>&lt;ul&gt;
+&lt;li&gt;New tabbed UI.&lt;/li&gt;
+&lt;li&gt;Update to DeepViolet 5.1.16.&lt;/li&gt;
+&lt;/ul&gt;</changes>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/httpsInfo-v12/httpsInfo-alpha-12.zap</url>
+        <hash>SHA1:c9c44e815522b32f3870bae898ed4e76e9011207</hash>
+        <date>2019-04-26</date>
+        <size>7690429</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_httpsInfo>
     <addon>hud</addon>


### PR DESCRIPTION
Per: `...\zap-admin>gradlew updateAddOnRelease --url=https://github.com/zaproxy/zap-extensions/releases/download/httpsInfo-v12/httpsInfo-alpha-12.zap`