### PR TITLE
Update add-ons only for 2.8 and dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ tasks {
     }
 
     register<UpdateAddOnZapVersionsEntries>("updateAddOnRelease") {
-        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.8.xml"))
+        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.7.xml", "ZapVersions-2.8.xml"))
         checksumAlgorithm.set("SHA-256")
     }
 }


### PR DESCRIPTION
Change `updateAddOnRelease` task to no longer update 2.7, now targeting
just latest release.