### PR TITLE
Remove 2.7 from add-on update task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ tasks {
     }
 
     register<UpdateAddOnZapVersionsEntries>("updateAddOnRelease") {
-        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.7.xml", "ZapVersions-2.8.xml"))
+        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.8.xml"))
         checksumAlgorithm.set("SHA-256")
     }
 }


### PR DESCRIPTION
The version 2.7 was accidentally added in a previous change...