### PR TITLE
Use just OpenJDK in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Replace OracleJDK with OpenJDK, the former is no longer included by
default in newer dists (Xenial).
Also, run with Java 11 to make sure everything works with newer Java
version.