### PR TITLE
wappalyzer: release version 14

### DIFF
--- a/ZapVersions-2.8.xml
+++ b/ZapVersions-2.8.xml
@@ -1593,16 +1593,16 @@ URIs ending with specified file extensions are ignored from making requests to t
         <name>Wappalyzer - Technology Detection</name>
         <description>Technology detection using Wappalyzer: wappalyzer.com</description>
         <author>ZAP Dev Team</author>
-        <version>13</version>
-        <file>wappalyzer-alpha-13.zap</file>
+        <version>14</version>
+        <file>wappalyzer-alpha-14.zap</file>
         <status>alpha</status>
         <changes>&lt;ul&gt;
-&lt;li&gt;Performance improvements.&lt;/li&gt;
+&lt;li&gt;Update apps.json and icons to align with AliasIO/Wappalyzer release 5.8.4 (plus any subsequent PRs).&lt;/li&gt;
 &lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/wappalyzer-v13/wappalyzer-alpha-13.zap</url>
-        <hash>SHA-256:f8029683a1717c76989e9dae7092605200b783017bcf14b2d2f416dca15a7af9</hash>
-        <date>2019-08-19</date>
-        <size>2280650</size>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/wappalyzer-v14/wappalyzer-alpha-14.zap</url>
+        <hash>SHA-256:81898ed519b1246cf9d10af7d3203912c604e3fd0c2dfd2583ef2319eb68f677</hash>
+        <date>2019-10-02</date>
+        <size>2396959</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_wappalyzer>
     <addon>webdriverlinux</addon>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -1475,16 +1475,16 @@ URIs ending with specified file extensions are ignored from making requests to t
         <name>Wappalyzer - Technology Detection</name>
         <description>Technology detection using Wappalyzer: wappalyzer.com</description>
         <author>ZAP Dev Team</author>
-        <version>13</version>
-        <file>wappalyzer-alpha-13.zap</file>
+        <version>14</version>
+        <file>wappalyzer-alpha-14.zap</file>
         <status>alpha</status>
         <changes>&lt;ul&gt;
-&lt;li&gt;Performance improvements.&lt;/li&gt;
+&lt;li&gt;Update apps.json and icons to align with AliasIO/Wappalyzer release 5.8.4 (plus any subsequent PRs).&lt;/li&gt;
 &lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/wappalyzer-v13/wappalyzer-alpha-13.zap</url>
-        <hash>SHA-256:f8029683a1717c76989e9dae7092605200b783017bcf14b2d2f416dca15a7af9</hash>
-        <date>2019-08-19</date>
-        <size>2280650</size>
+        <url>https://github.com/zaproxy/zap-extensions/releases/download/wappalyzer-v14/wappalyzer-alpha-14.zap</url>
+        <hash>SHA-256:81898ed519b1246cf9d10af7d3203912c604e3fd0c2dfd2583ef2319eb68f677</hash>
+        <date>2019-10-02</date>
+        <size>2396959</size>
         <not-before-version>2.7.0</not-before-version>
     </addon_wappalyzer>
     <addon>webdriverlinux</addon>


### PR DESCRIPTION
Release version 14 of Wappalyzer - Technology Detection add-on.