### PR TITLE
Use milestone for release notes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,7 @@ tasks.withType<JavaCompile> {
 }
 
 repositories {
-    mavenLocal()
-    mavenCentral()
+    jcenter()
 }
 
 buildDir = file("buildGradle")
@@ -40,6 +39,9 @@ buildDir = file("buildGradle")
 dependencies {
     "errorprone"("com.google.errorprone:error_prone_core:2.3.1")
 
+    compile("org.kohsuke:github-api:1.101")
+    compileOnly("com.infradna.tool:bridge-method-annotation:1.18")
+    compileOnly("com.github.spotbugs:spotbugs-annotations:3.1.12")
     compile("net.sf.json-lib:json-lib:2.4:jdk15")
     compile("org.zaproxy:zap:2.7.0")
 

--- a/src/main/java/org/zaproxy/admin/HelpGenerator.java
+++ b/src/main/java/org/zaproxy/admin/HelpGenerator.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -66,13 +67,13 @@ public class HelpGenerator {
             }
         } else {
             try {
-                String fileContents = FileUtils.readFileToString(srcFile);
+                String fileContents = FileUtils.readFileToString(srcFile, StandardCharsets.UTF_8);
 
                 for (Entry<String, String> entry : tokens.entrySet()) {
                     fileContents = fileContents.replaceAll(entry.getKey(), entry.getValue());
                 }
 
-                FileUtils.write(destFile, fileContents);
+                FileUtils.write(destFile, fileContents, StandardCharsets.UTF_8);
                 System.out.println("Created file " + destFile.getAbsolutePath());
 
             } catch (IOException e) {


### PR DESCRIPTION
Change `GenerateReleaseNotes` to obtain the issues from the milestone
number (using an API client).
Address deprecations in `HelpGenerator`, required by (transitive) update
of Apache Commons IO library.