### PR TITLE
No longer update the 2.8 marketplace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,7 @@ tasks {
     }
 
     register<UpdateAddOnZapVersionsEntries>("updateAddOnRelease") {
-        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.8.xml", "ZapVersions-2.9.xml"))
+        into.setFrom(files("ZapVersions-dev.xml", "ZapVersions-2.9.xml"))
         checksumAlgorithm.set("SHA-256")
     }
 }


### PR DESCRIPTION
Otherwise 2.8 users will get a flood of add-on updates as we regenerate them for 2.9

Signed-off-by: Simon Bennetts <psiinon@gmail.com>