### PR TITLE
Update zaproxy-website on release changes

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,30 @@
+name: Update Website
+
+on:
+  push:
+    branch:
+    - master
+    paths:
+    - ZapVersions*.xml
+
+jobs:
+  update-website:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: zap-admin
+    - name: Checkout zaproxy-website
+      uses: actions/checkout@v2
+      with:
+        repository: zaproxy/zaproxy-website
+        persist-credentials: false
+        path: zaproxy-website
+    - name: Setup Java 8
+      uses: actions/setup-java@v1
+      java-version: 8
+    - name: Update Website
+      run: cd zap-admin && ./gradlew updateWebsite
+      env:
+        ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,6 +11,11 @@ dependencies {
     implementation("commons-configuration:commons-configuration:1.9")
     implementation("commons-jxpath:commons-jxpath:1.3")
     implementation("commons-codec:commons-codec:1.11")
+    val jgitVersion = "5.6.0.201912101111-r"
+    implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
+    implementation("org.eclipse.jgit:org.eclipse.jgit.archive:$jgitVersion")
+    implementation("org.kohsuke:github-api:1.106")
+    implementation("org.snakeyaml:snakeyaml-engine:2.0")
 }
 
 spotless {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/AbstractGenerateWebsiteReleaseData.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AbstractGenerateWebsiteReleaseData.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.util.List;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.gradle.ReleaseData.ReleaseFile;
+
+/** An abstract task for generation of release data for the website. */
+public abstract class AbstractGenerateWebsiteReleaseData extends DefaultTask {
+
+    private static final double MEGABYTE = 1024 * 1024;
+
+    private final RegularFileProperty zapVersions;
+    private final Property<String> generatedDataComment;
+    private final RegularFileProperty into;
+
+    public AbstractGenerateWebsiteReleaseData(String releaseName) {
+        ObjectFactory objects = getProject().getObjects();
+        this.zapVersions = objects.fileProperty();
+        this.generatedDataComment = objects.property(String.class);
+        this.into = objects.fileProperty();
+
+        setGroup("ZAP");
+        setDescription("Generates the " + releaseName + " release data for the website.");
+    }
+
+    @InputFile
+    public RegularFileProperty getZapVersions() {
+        return zapVersions;
+    }
+
+    @Input
+    public Property<String> getGeneratedDataComment() {
+        return generatedDataComment;
+    }
+
+    @OutputFile
+    public RegularFileProperty getInto() {
+        return into;
+    }
+
+    @TaskAction
+    public void generate() throws Exception {
+        XMLConfiguration zapVersionsXml = new CustomXmlConfiguration();
+        zapVersionsXml.load(zapVersions.get().getAsFile());
+
+        ReleaseData releaseData = new ReleaseData(createReleaseFiles(zapVersionsXml));
+        releaseData.save(into.get().getAsFile().toPath(), generatedDataComment.get());
+    }
+
+    protected abstract List<ReleaseFile> createReleaseFiles(XMLConfiguration zapVersionsXml)
+            throws Exception;
+
+    protected static String toMegaBytes(String value) {
+        return toMegaBytes(Long.parseLong(value));
+    }
+
+    protected static String toMegaBytes(long value) {
+        return Math.round(value / MEGABYTE) + " MB";
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteMainReleaseData.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteMainReleaseData.java
@@ -1,0 +1,165 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.kohsuke.github.GHAsset;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.zaproxy.gradle.ReleaseData.ReleaseFile;
+
+/** A task that generates the main release data for the website. */
+public class GenerateWebsiteMainReleaseData extends AbstractGenerateWebsiteReleaseData {
+
+    private static final String CORE_VERSION_ELEMENT = "core.version";
+    private static final String TAG_PREFIX = "v";
+
+    private final Property<String> ghUserName;
+    private final Property<String> ghUserAuthToken;
+
+    private final Property<String> ghBaseUserName;
+    private final Property<String> ghBaseRepo;
+
+    public GenerateWebsiteMainReleaseData() {
+        super("main");
+
+        ObjectFactory objects = getProject().getObjects();
+        this.ghUserName = objects.property(String.class);
+        this.ghUserAuthToken = objects.property(String.class);
+        this.ghBaseUserName = objects.property(String.class);
+        this.ghBaseRepo = objects.property(String.class);
+
+        // Execute always, in case release assets have changed.
+        getOutputs().upToDateWhen(task -> false);
+    }
+
+    @Internal
+    @Optional
+    public Property<String> getGhUserName() {
+        return ghUserName;
+    }
+
+    @Internal
+    @Optional
+    public Property<String> getGhUserAuthToken() {
+        return ghUserAuthToken;
+    }
+
+    @Internal
+    public Property<String> getGhBaseUserName() {
+        return ghBaseUserName;
+    }
+
+    @Internal
+    public Property<String> getGhBaseRepo() {
+        return ghBaseRepo;
+    }
+
+    @Override
+    protected List<ReleaseFile> createReleaseFiles(XMLConfiguration zapVersionsXml)
+            throws IOException {
+        GHRepository repo =
+                createGitHubConnection(ghUserName.getOrNull(), ghUserAuthToken.getOrNull())
+                        .getRepository(ghBaseUserName.get() + "/" + ghBaseRepo.get());
+
+        List<GHAsset> assets =
+                repo.getReleaseByTagName(
+                                TAG_PREFIX + zapVersionsXml.getString(CORE_VERSION_ELEMENT))
+                        .getAssets();
+
+        List<ReleaseFile> releaseFiles = new ArrayList<>();
+
+        GHAsset asset = getAsset(assets, "windows.exe");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Windows (64) Installer",
+                        "win-64-i",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, "windows-x32.exe");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Windows (32) Installer",
+                        "win-32-i",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, "unix.sh");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Linux Installer",
+                        "nix-i",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, "Linux.tar.gz");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Linux Package",
+                        "nix-p",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, ".dmg");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "MacOS Installer",
+                        "osx-i",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, "Crossplatform.zip");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Cross Platform Package",
+                        "cp-p",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        asset = getAsset(assets, "Core.zip");
+        releaseFiles.add(
+                new ReleaseFile(
+                        "Core Cross Platform Package",
+                        "cp-c",
+                        toMegaBytes(asset.getSize()),
+                        asset.getBrowserDownloadUrl()));
+
+        return releaseFiles;
+    }
+
+    private GHAsset getAsset(List<GHAsset> assets, String suffix) {
+        return assets.stream().filter(asset -> asset.getName().endsWith(suffix)).findFirst().get();
+    }
+
+    private GitHub createGitHubConnection(String userName, String authToken) throws IOException {
+        if (authToken == null || authToken.isEmpty()) {
+            return GitHub.connectAnonymously();
+        }
+        return GitHub.connect(userName, authToken);
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteWeeklyReleaseData.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteWeeklyReleaseData.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.zaproxy.gradle.ReleaseData.ReleaseFile;
+
+/** A task that generates the weekly release data for the website. */
+public class GenerateWebsiteWeeklyReleaseData extends AbstractGenerateWebsiteReleaseData {
+
+    private static final String DAILY_ELEMENT = "core.daily";
+    private static final String DAILY_SIZE_ELEMENT = DAILY_ELEMENT + ".size";
+    private static final String DAILY_URL_ELEMENT = DAILY_ELEMENT + ".url";
+
+    public GenerateWebsiteWeeklyReleaseData() {
+        super("weekly");
+    }
+
+    @Override
+    protected List<ReleaseFile> createReleaseFiles(XMLConfiguration zapVersionsXml) {
+        return Collections.singletonList(
+                new ReleaseFile(
+                        "Weekly Cross Platform Package",
+                        "cp-p",
+                        toMegaBytes(zapVersionsXml.getString(DAILY_SIZE_ELEMENT)),
+                        zapVersionsXml.getString(DAILY_URL_ELEMENT)));
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/ReleaseData.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/ReleaseData.java
@@ -1,0 +1,140 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.api.RepresentToNode;
+import org.snakeyaml.engine.v2.api.StreamDataWriter;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.snakeyaml.engine.v2.nodes.MappingNode;
+import org.snakeyaml.engine.v2.nodes.Node;
+import org.snakeyaml.engine.v2.nodes.NodeTuple;
+import org.snakeyaml.engine.v2.nodes.ScalarNode;
+import org.snakeyaml.engine.v2.nodes.Tag;
+import org.snakeyaml.engine.v2.representer.StandardRepresenter;
+
+class ReleaseData {
+
+    private static final DumpSettings SETTINGS =
+            DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK).build();
+    private static final Dump DUMP = new Dump(SETTINGS, new ReleaseFileRepresenter(SETTINGS));
+
+    private final List<ReleaseFile> releaseFiles;
+
+    public ReleaseData(List<ReleaseFile> releaseFiles) {
+        this.releaseFiles = new ArrayList<>(releaseFiles);
+    }
+
+    public void save(Path file, String comment) throws IOException {
+        try (Writer writer = Files.newBufferedWriter(file)) {
+            writer.write(comment);
+            writer.write("\n---\n");
+            DUMP.dump(releaseFiles, new StreamDataWriterAdapter(writer));
+        } catch (UncheckedIOException e) {
+            throw new IOException("Failed to save to: " + file, e.getCause());
+        }
+    }
+
+    static class ReleaseFile {
+        private final String name;
+        private final String id;
+        private final String size;
+        private final String link;
+
+        ReleaseFile(String name, String id, String size, String link) {
+            this.name = name;
+            this.id = id;
+            this.size = size;
+            this.link = link;
+        }
+    }
+
+    private static class ReleaseFileRepresenter extends StandardRepresenter {
+
+        ReleaseFileRepresenter(DumpSettings settings) {
+            super(settings);
+            this.representers.put(ReleaseFile.class, new RepresentReleaseFile());
+        }
+
+        private class RepresentReleaseFile implements RepresentToNode {
+
+            @Override
+            public Node representData(Object data) {
+                ReleaseFile releaseFile = (ReleaseFile) data;
+                List<NodeTuple> nodeData = new ArrayList<>(4);
+                MappingNode node =
+                        new MappingNode(Tag.MAP, nodeData, settings.getDefaultFlowStyle());
+                nodeData.add(new NodeTuple(string("name"), string(releaseFile.name)));
+                nodeData.add(new NodeTuple(string("id"), string(releaseFile.id)));
+                nodeData.add(new NodeTuple(string("size"), string(releaseFile.size)));
+                nodeData.add(new NodeTuple(string("link"), string(releaseFile.link)));
+                return node;
+            }
+
+            private ScalarNode string(String value) {
+                return new ScalarNode(Tag.STR, value, settings.getDefaultScalarStyle());
+            }
+        }
+    }
+
+    private static class StreamDataWriterAdapter implements StreamDataWriter {
+
+        private final Writer writer;
+
+        StreamDataWriterAdapter(Writer writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public void write(String str) {
+            processIoAction(() -> writer.write(str));
+        }
+
+        @Override
+        public void write(String str, int off, int len) {
+            processIoAction(() -> writer.write(str, off, len));
+        }
+
+        @Override
+        public void flush() {
+            processIoAction(writer::flush);
+        }
+
+        private static void processIoAction(IoAction action) {
+            try {
+                action.apply();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private interface IoAction {
+        void apply() throws IOException;
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/UpdateWebsite.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/UpdateWebsite.java
@@ -1,0 +1,204 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+/** A task that creates a pull request updating the website with the generated data. */
+public class UpdateWebsite extends DefaultTask {
+
+    private static final String GITHUB_BASE_URL = "https://github.com/";
+
+    private static final String GIT_REMOTE_ORIGIN = "origin";
+
+    private static final String DEFAULT_GIT_BASE_BRANCH_NAME = "master";
+    private static final String DEFAULT_GIT_BRANCH_NAME = "update-data";
+
+    private final RegularFileProperty websiteRepo;
+
+    private final Property<String> gitBaseBranchName;
+    private final Property<String> gitBranchName;
+
+    private final Property<String> ghUserName;
+    private final Property<String> ghUserEmail;
+    private final Property<String> ghUserAuthToken;
+
+    private final Property<String> ghBaseUserName;
+    private final Property<String> ghBaseRepo;
+    private final Property<String> ghSourceRepo;
+
+    public UpdateWebsite() {
+        ObjectFactory objects = getProject().getObjects();
+
+        this.websiteRepo = objects.fileProperty();
+
+        this.gitBaseBranchName =
+                objects.property(String.class).convention(DEFAULT_GIT_BASE_BRANCH_NAME);
+        this.gitBranchName = objects.property(String.class).convention(DEFAULT_GIT_BRANCH_NAME);
+
+        this.ghUserName = objects.property(String.class);
+        this.ghUserEmail = objects.property(String.class);
+        this.ghUserAuthToken = objects.property(String.class);
+
+        this.ghBaseUserName = objects.property(String.class);
+        this.ghBaseRepo = objects.property(String.class);
+        this.ghSourceRepo = objects.property(String.class);
+
+        setGroup("ZAP");
+        setDescription("Creates a pull request updating the website with the generated data.");
+    }
+
+    @Internal
+    public RegularFileProperty getWebsiteRepo() {
+        return websiteRepo;
+    }
+
+    @Internal
+    public Property<String> getGitBaseBranchName() {
+        return gitBaseBranchName;
+    }
+
+    @Internal
+    public Property<String> getGitBranchName() {
+        return gitBranchName;
+    }
+
+    @Internal
+    public Property<String> getGhUserName() {
+        return ghUserName;
+    }
+
+    @Internal
+    public Property<String> getGhUserEmail() {
+        return ghUserEmail;
+    }
+
+    @Internal
+    public Property<String> getGhUserAuthToken() {
+        return ghUserAuthToken;
+    }
+
+    @Internal
+    public Property<String> getGhBaseUserName() {
+        return ghBaseUserName;
+    }
+
+    @Internal
+    public Property<String> getGhBaseRepo() {
+        return ghBaseRepo;
+    }
+
+    @Internal
+    public Property<String> getGhSourceRepo() {
+        return ghSourceRepo;
+    }
+
+    @TaskAction
+    public void update() throws Exception {
+        Repository repository =
+                new FileRepositoryBuilder()
+                        .setGitDir(new File(websiteRepo.get().getAsFile(), ".git"))
+                        .build();
+        try (Git git = new Git(repository)) {
+            if (git.status().call().getModified().isEmpty()) {
+                return;
+            }
+
+            URIish originUri =
+                    new URIish(GITHUB_BASE_URL + ghUserName.get() + "/" + ghBaseRepo.get());
+            git.remoteSetUrl().setRemoteName(GIT_REMOTE_ORIGIN).setRemoteUri(originUri).call();
+
+            git.checkout()
+                    .setCreateBranch(true)
+                    .setName(gitBranchName.get())
+                    .setStartPoint(GIT_REMOTE_ORIGIN + "/" + gitBaseBranchName.get())
+                    .call();
+
+            String sourceCommitSha = getHeadCommit(getProject().getRootDir());
+
+            String commitSummary = "Update data";
+            String commitDescription =
+                    "From:\n"
+                            + ghBaseUserName.get()
+                            + "/"
+                            + ghSourceRepo.get()
+                            + "@"
+                            + sourceCommitSha;
+
+            PersonIdent personIdent = new PersonIdent(ghUserName.get(), ghUserEmail.get());
+            git.commit()
+                    .setAll(true)
+                    .setSign(false)
+                    .setAuthor(personIdent)
+                    .setCommitter(personIdent)
+                    .setMessage(commitSummary + "\n\n" + commitDescription + signedOffBy())
+                    .call();
+
+            git.push()
+                    .setCredentialsProvider(
+                            new UsernamePasswordCredentialsProvider(
+                                    ghUserName.get(), ghUserAuthToken.get()))
+                    .setForce(true)
+                    .add(gitBranchName.get())
+                    .call();
+
+            createPullRequest(commitSummary, commitDescription);
+        }
+    }
+
+    private String signedOffBy() {
+        return "\n\nSigned-off-by: " + ghUserName.get() + " <" + ghUserEmail.get() + ">";
+    }
+
+    private void createPullRequest(String title, String description) throws IOException {
+        GHRepository ghRepo =
+                GitHub.connect(ghUserName.get(), ghUserAuthToken.get())
+                        .getRepository(ghBaseUserName.get() + "/" + ghBaseRepo.get());
+        ghRepo.createPullRequest(
+                title,
+                ghUserName.get() + ":" + gitBranchName.get(),
+                gitBaseBranchName.get(),
+                description);
+    }
+
+    private static String getHeadCommit(File repoDir) throws IOException {
+        return new FileRepositoryBuilder()
+                .setGitDir(new File(repoDir, ".git"))
+                .build()
+                .exactRef("HEAD")
+                .getObjectId()
+                .getName();
+    }
+}


### PR DESCRIPTION
Update weekly and main release website data when the ZapVersions files
are changed.
The GitHub Action will create a pull request (using @zapbot) with the
changes.