### PR TITLE
Fix branch filter in update-website workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -2,7 +2,7 @@ name: Update Website
 
 on:
   push:
-    branch:
+    branches:
     - master
     paths:
     - ZapVersions*.xml


### PR DESCRIPTION
Use correct name `branch` → `branches`.