### PR TITLE
Release weekly Docker image on weekly release

### DIFF
--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -1,4 +1,4 @@
-name: Update Website
+name: Handle Release
 
 on:
   push:
@@ -8,13 +8,14 @@ on:
     - ZapVersions*.xml
 
 jobs:
-  update-website:
+  handle-release:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         path: zap-admin
+        depth: 10
     - name: Checkout zaproxy-website
       uses: actions/checkout@v2
       with:
@@ -27,6 +28,6 @@ jobs:
       with:
         java-version: 8
     - name: Update Website
-      run: cd zap-admin && ./gradlew updateWebsite
+      run: cd zap-admin && ./gradlew handleRelease
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit.archive:$jgitVersion")
     implementation("org.kohsuke:github-api:1.106")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
     implementation("org.snakeyaml:snakeyaml-engine:2.0")
     implementation("org.zaproxy:zap:2.9.0")
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/GenerateReleaseStateLastCommit.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/GenerateReleaseStateLastCommit.java
@@ -1,0 +1,281 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.apache.commons.configuration.ConfigurationException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilterGroup;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/**
+ * A task that generates the release state of the last commit, allowing to know what was released
+ * (if anything).
+ */
+public abstract class GenerateReleaseStateLastCommit extends DefaultTask {
+
+    private static final String CORE_ELEMENT = "core.";
+    private static final String MAIN_VERSION_ELEMENT = CORE_ELEMENT + "version";
+    private static final String DAILY_VERSION_ELEMENT = CORE_ELEMENT + "daily-version";
+
+    private static final String GIT_DIR = ".git";
+    private static final String HEAD_REF = "HEAD";
+
+    public GenerateReleaseStateLastCommit() {
+        getGitDir().value(getProject().getLayout().getProjectDirectory().dir(GIT_DIR));
+    }
+
+    @InputDirectory
+    public abstract DirectoryProperty getGitDir();
+
+    @Input
+    public abstract Property<String> getZapVersionsPath();
+
+    @OutputFile
+    public abstract RegularFileProperty getReleaseState();
+
+    @TaskAction
+    void generate() {
+        File gitDir = getGitDir().get().getAsFile();
+
+        ReleaseState releaseState = new ReleaseState();
+        readVersions(
+                gitDir,
+                getZapVersionsPath().get(),
+                (previousVersions, currentVersions) -> {
+                    updateState(
+                            MAIN_VERSION_ELEMENT,
+                            previousVersions,
+                            currentVersions,
+                            releaseState::setMainRelease);
+                    updateState(
+                            DAILY_VERSION_ELEMENT,
+                            previousVersions,
+                            currentVersions,
+                            releaseState::setWeeklyRelease);
+                });
+
+        releaseState.write(getReleaseState().get().getAsFile());
+    }
+
+    private static void readVersions(
+            File projectDir,
+            String pathZapVersions,
+            BiConsumer<ZapXmlConfiguration, ZapXmlConfiguration> versionsConsumer) {
+        try (Repository repository = createRepository(projectDir);
+                RevWalk walk = new RevWalk(repository)) {
+            RevCommit headCommit = walk.parseCommit(getHead(repository).getObjectId());
+
+            walk.markStart(headCommit);
+            ZapXmlConfiguration currentVersions = null;
+            Iterator<RevCommit> it = walk.iterator();
+            if (it.hasNext()) {
+                try (TreeWalk treeWalk = new TreeWalk(repository)) {
+                    treeWalk.addTree(walk.parseTree(it.next().getTree().getId()));
+                    treeWalk.setRecursive(true);
+                    treeWalk.setFilter(PathFilterGroup.createFromStrings(pathZapVersions));
+                    if (treeWalk.next()) {
+                        currentVersions =
+                                createXmlConfiguration(repository, treeWalk.getObjectId(0));
+                    }
+                }
+            }
+            if (currentVersions == null) {
+                throw new TaskException("File not found in the current commit: " + pathZapVersions);
+            }
+
+            RevCommit parent;
+            if (isMergeCommit(headCommit)) {
+                parent =
+                        getCommonAncestor(
+                                repository,
+                                headCommit.getParent(0).getId(),
+                                headCommit.getParent(1).getId());
+            } else {
+                parent = headCommit.getParent(0);
+            }
+
+            ZapXmlConfiguration previousVersions = currentVersions;
+            Optional<DiffEntry> diffResult =
+                    isFileChanged(repository, parent, headCommit, pathZapVersions);
+            if (diffResult.isPresent()) {
+                previousVersions =
+                        createXmlConfiguration(
+                                repository, diffResult.get().getOldId().toObjectId());
+            }
+
+            versionsConsumer.accept(previousVersions, currentVersions);
+        } catch (IOException e) {
+            throw new TaskException(
+                    "An error occurred while using the Git repository: " + e.getMessage(), e);
+        }
+    }
+
+    private static Repository createRepository(File projectDir) {
+        try {
+            return new FileRepositoryBuilder().setGitDir(projectDir).build();
+        } catch (IOException e) {
+            throw new TaskException("Failed to read the Git repository: " + e.getMessage(), e);
+        }
+    }
+
+    private static Ref getHead(Repository repository) {
+        Ref head;
+        try {
+            head = repository.findRef(HEAD_REF);
+        } catch (IOException e) {
+            throw new TaskException(
+                    String.format(
+                            "Failed to get the ref %s from the Git repository: %s",
+                            HEAD_REF, e.getMessage()),
+                    e);
+        }
+        if (head == null) {
+            throw new TaskException(
+                    String.format("No ref %s found in the Git repository.", HEAD_REF));
+        }
+        return head;
+    }
+
+    private static boolean isMergeCommit(RevCommit commit) {
+        return commit.getParentCount() > 1;
+    }
+
+    private static ZapXmlConfiguration createXmlConfiguration(
+            Repository repository, ObjectId objectId) {
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        try {
+            config.load(repository.open(objectId).openStream());
+        } catch (ConfigurationException | IOException e) {
+            throw new TaskException(
+                    "Failed to read the file from the Git repository: " + e.getMessage(), e);
+        }
+        return config;
+    }
+
+    private static void updateState(
+            String versionElement,
+            ZapXmlConfiguration previousVersions,
+            ZapXmlConfiguration currentVersions,
+            Consumer<ReleaseState.VersionChange> consumer) {
+        consumer.accept(
+                new ReleaseState.VersionChange(
+                        previousVersions.getString(versionElement),
+                        currentVersions.getString(versionElement)));
+    }
+
+    private static RevCommit getCommonAncestor(
+            Repository repository, ObjectId commitA, ObjectId commitB) {
+        List<RevCommit> treeA = walkTree(repository, commitA, 50);
+        List<RevCommit> treeB = walkTree(repository, commitB, 50);
+
+        Set<RevCommit> common = new HashSet<>(treeA);
+        for (RevCommit commit : treeB) {
+            if (!common.add(commit)) {
+                return commit;
+            }
+        }
+
+        throw new TaskException("Common ancestor not found between " + commitA + " and " + commitB);
+    }
+
+    private static List<RevCommit> walkTree(Repository repository, ObjectId start, int count) {
+        List<RevCommit> commits = new ArrayList<>();
+        try (RevWalk revWalk = new RevWalk(repository)) {
+            revWalk.markStart(revWalk.parseCommit(start));
+            for (RevCommit commit : revWalk) {
+                commits.add(commit);
+                if (commits.size() >= count) {
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw new TaskException(
+                    "An error occurred while traversing the commit tree: " + e.getMessage(), e);
+        }
+        return commits;
+    }
+
+    private static AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId)
+            throws IOException {
+        try (RevWalk walk = new RevWalk(repository)) {
+            RevTree tree = walk.parseTree(walk.parseCommit(objectId).getTree().getId());
+
+            CanonicalTreeParser treeParser = new CanonicalTreeParser();
+            try (ObjectReader reader = repository.newObjectReader()) {
+                treeParser.reset(reader, tree.getId());
+            }
+            return treeParser;
+        }
+    }
+
+    private static Optional<DiffEntry> isFileChanged(
+            Repository repository, RevCommit commitA, RevCommit commitB, String filePath) {
+        try (Git git = new Git(repository);
+                ObjectReader reader = git.getRepository().newObjectReader()) {
+            AbstractTreeIterator oldTree = prepareTreeParser(repository, commitA);
+            AbstractTreeIterator newTree = prepareTreeParser(repository, commitB);
+            return git.diff()
+                    .setOldTree(oldTree)
+                    .setNewTree(newTree)
+                    .call()
+                    .stream()
+                    .filter(
+                            e ->
+                                    e.getChangeType() == DiffEntry.ChangeType.MODIFY
+                                            && e.getNewPath().equals(filePath))
+                    .findFirst();
+
+        } catch (GitAPIException | IOException e) {
+            throw new TaskException(
+                    "An error occurred while diffing the commits: " + e.getMessage(), e);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/HandleWeeklyRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/HandleWeeklyRelease.java
@@ -1,0 +1,48 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.zaproxy.gradle.ReleaseState.VersionChange;
+
+/**
+ * Task that handles a weekly release, if any.
+ *
+ * <p>Sends a repository dispatch to release the Docker weekly image.
+ */
+public abstract class HandleWeeklyRelease extends SendRepositoryDispatch {
+
+    @InputFile
+    public abstract RegularFileProperty getReleaseState();
+
+    @Override
+    void send() {
+        ReleaseState releaseState = ReleaseState.read(getReleaseState().getAsFile().get());
+        if (isNewWeeklyRelease(releaseState)) {
+            super.send();
+        }
+    }
+
+    private static boolean isNewWeeklyRelease(ReleaseState releaseState) {
+        VersionChange weeklyRelease = releaseState.getWeeklyRelease();
+        return weeklyRelease != null && weeklyRelease.isNewVersion();
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/ReleaseState.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/ReleaseState.java
@@ -1,0 +1,124 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.io.File;
+import java.io.IOException;
+
+/** The release state computed from {@code ZapVersions.xml} files. */
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonInclude(value = Include.NON_NULL)
+public class ReleaseState {
+
+    @JsonProperty private VersionChange mainRelease;
+    @JsonProperty private VersionChange weeklyRelease;
+
+    public ReleaseState() {}
+
+    public VersionChange getMainRelease() {
+        return mainRelease;
+    }
+
+    public void setMainRelease(VersionChange mainRelease) {
+        this.mainRelease = mainRelease;
+    }
+
+    public VersionChange getWeeklyRelease() {
+        return weeklyRelease;
+    }
+
+    public void setWeeklyRelease(VersionChange weeklyRelease) {
+        this.weeklyRelease = weeklyRelease;
+    }
+
+    /**
+     * Writes this {@code ReleaseState} to the given file.
+     *
+     * @param file the file to write the release state.
+     * @throws TaskException if an error occurred while writing the release state.
+     */
+    public void write(File file) {
+        try {
+            new ObjectMapper().writeValue(file, this);
+        } catch (IOException e) {
+            throw new TaskException("Failed to write the release state: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reads a {@code ReleaseState} from the given file.
+     *
+     * @param file the file with the release state.
+     * @return a new {@code ReleaseState} with the contents from the file.
+     * @throws TaskException if an error occurred while reading the release state.
+     */
+    public static ReleaseState read(File file) {
+        try {
+            return new ObjectMapper().readValue(file, ReleaseState.class);
+        } catch (IOException e) {
+            throw new TaskException("Failed to read the release state: " + e.getMessage(), e);
+        }
+    }
+
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonInclude(value = Include.NON_EMPTY)
+    public static class VersionChange {
+
+        @JsonProperty private String previousVersion;
+
+        @JsonProperty private String currentVersion;
+
+        @JsonProperty private boolean newVersion;
+
+        public VersionChange() {}
+
+        public VersionChange(String previousVersion, String currentVersion) {
+            this.previousVersion = previousVersion;
+            this.currentVersion = currentVersion;
+            this.newVersion = previousVersion == null || !previousVersion.equals(currentVersion);
+        }
+
+        public boolean isNewVersion() {
+            return newVersion;
+        }
+
+        public String getPreviousVersion() {
+            return previousVersion;
+        }
+
+        public void setPreviousVersion(String previousVersion) {
+            this.previousVersion = previousVersion;
+        }
+
+        public String getCurrentVersion() {
+            return currentVersion;
+        }
+
+        public void setCurrentVersion(String currentVersion) {
+            this.currentVersion = currentVersion;
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/SendRepositoryDispatch.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/SendRepositoryDispatch.java
@@ -1,0 +1,168 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task that sends a {@code repository_dispatch} to a GitHub repo. */
+public abstract class SendRepositoryDispatch extends DefaultTask {
+
+    private static final int EXPECTED_STATUS_CODE = HttpURLConnection.HTTP_NO_CONTENT;
+    private static final int NO_STATUS_CODE = -1;
+
+    @Input
+    public abstract Property<String> getGhUserName();
+
+    @Input
+    public abstract Property<String> getGhUserAuthToken();
+
+    @Input
+    public abstract Property<String> getGhBaseUserName();
+
+    @Input
+    public abstract Property<String> getGhBaseRepo();
+
+    @Input
+    public abstract Property<String> getEventType();
+
+    @Input
+    @Optional
+    public abstract MapProperty<String, Object> getClientPayload();
+
+    @TaskAction
+    void send() {
+        HttpURLConnection connection = createConnection();
+        writeRepositoryDispatch(connection);
+
+        int statusCode = getStatusCode(connection);
+        if (statusCode == EXPECTED_STATUS_CODE) {
+            return;
+        }
+
+        if (statusCode == NO_STATUS_CODE) {
+            throw new TaskException("Unable to get a response.");
+        }
+
+        StringBuilder errorMessage = new StringBuilder();
+        errorMessage.append(
+                String.format(
+                        "Repository dispatch was not successful, expected status code %s received %s.",
+                        EXPECTED_STATUS_CODE, statusCode));
+
+        String response = readResponse(connection);
+        if (response != null && !response.isEmpty()) {
+            errorMessage.append("\nResponse:\n").append(response);
+        }
+        throw new TaskException(errorMessage.toString());
+    }
+
+    private HttpURLConnection createConnection() {
+        String url =
+                String.format(
+                        "https://api.github.com/repos/%s/%s/dispatches",
+                        getGhBaseUserName().get(), getGhBaseRepo().get());
+        HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) new URL(url).openConnection();
+        } catch (IOException e) {
+            throw new TaskException("Failed to create the connection:", e);
+        }
+        connection.setDoOutput(true);
+        connection.setUseCaches(false);
+        try {
+            connection.setRequestMethod("POST");
+        } catch (ProtocolException e) {
+            throw new TaskException("Failed to create the connection:", e);
+        }
+        connection.setRequestProperty("Accept", "application/vnd.github.v3+json");
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        String userName = getGhUserName().get();
+        String token = getGhUserAuthToken().get();
+        byte[] usernameAuthToken = (userName + ":" + token).getBytes(StandardCharsets.UTF_8);
+        String authorization = "Basic " + Base64.getEncoder().encodeToString(usernameAuthToken);
+        connection.setRequestProperty("Authorization", authorization);
+
+        return connection;
+    }
+
+    private void writeRepositoryDispatch(HttpURLConnection connection) {
+        byte[] repositoryDispatch;
+        try {
+            repositoryDispatch = createRepositoryDispatch();
+        } catch (JsonProcessingException e) {
+            throw new TaskException("Failed to create the request body:", e);
+        }
+
+        try (OutputStream os = connection.getOutputStream()) {
+            os.write(repositoryDispatch);
+        } catch (IOException e) {
+            throw new TaskException("Failed to write the repository dispatch:", e);
+        }
+    }
+
+    private byte[] createRepositoryDispatch() throws JsonProcessingException {
+        Map<String, Object> repositoryDispatch = new LinkedHashMap<>();
+        repositoryDispatch.put("event_type", getEventType().get());
+
+        Map<String, Object> clientPayload = getClientPayload().getOrNull();
+        if (clientPayload != null && !clientPayload.isEmpty()) {
+            repositoryDispatch.put("client_payload", clientPayload);
+        }
+
+        return new ObjectMapper().writeValueAsBytes(repositoryDispatch);
+    }
+
+    private int getStatusCode(HttpURLConnection connection) {
+        try {
+            return connection.getResponseCode();
+        } catch (IOException e) {
+            getLogger()
+                    .warn("Failed to read the repository dispatch status code: " + e.getMessage());
+        }
+        return NO_STATUS_CODE;
+    }
+
+    private String readResponse(HttpURLConnection connection) {
+        try {
+            return IOUtils.toString(connection.getErrorStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            getLogger().warn("Failed to read the repository dispatch response: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/TaskException.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/TaskException.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+/** An exception that occurred while running a task. */
+public class TaskException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TaskException(String message) {
+        super(message);
+    }
+
+    public TaskException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Send repository dispatch to zaproxy to build the weekly Docker image
when the weekly is released.
Renamed `update-website` workflow to `handle-release` to match/include
the new behaviour.