### PR TITLE
Fix Handle Release workflow

### DIFF
--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: zap-admin
-        depth: 10
+        fetch-depth: 10
     - name: Checkout zaproxy-website
       uses: actions/checkout@v2
       with:
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
-    - name: Update Website
+    - name: Handle Release
       run: cd zap-admin && ./gradlew handleRelease
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}

--- a/ZapVersions.xml
+++ b/ZapVersions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ZAP>
+<ZAP> 
     <core>
         <version>2.9.0</version>
         <daily-version>D-2020-08-03</daily-version>


### PR DESCRIPTION
Correct the name of the action input (`depth` → `fetch-depth`).
Tweak the name of a step.
Touch one of the `ZapVersions.xml` files to trigger the workflow.