### PR TITLE
Release main Docker images on main release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.zaproxy.gradle.GenerateReleaseStateLastCommit
 import org.zaproxy.gradle.GenerateWebsiteAddonsData
 import org.zaproxy.gradle.GenerateWebsiteMainReleaseData
 import org.zaproxy.gradle.GenerateWebsiteWeeklyReleaseData
+import org.zaproxy.gradle.HandleMainRelease
 import org.zaproxy.gradle.HandleWeeklyRelease
 import org.zaproxy.gradle.UpdateAddOnZapVersionsEntries
 import org.zaproxy.gradle.UpdateDailyZapVersionsEntries
@@ -215,9 +216,22 @@ val handleWeeklyRelease by tasks.registering(HandleWeeklyRelease::class) {
     eventType.set("release-weekly-docker")
 }
 
+val handleMainRelease by tasks.registering(HandleMainRelease::class) {
+    releaseState.set(generateReleaseStateLastCommit.map { it.releaseState.get() })
+
+    ghUserName.set(ghUser.name)
+    ghUserAuthToken.set(ghUser.authToken)
+
+    ghBaseUserName.set(baseUserName)
+    ghBaseRepo.set(zaproxyRepo)
+
+    eventType.set("release-main-docker")
+}
+
 tasks.register("handleRelease") {
     dependsOn(updateWebsite)
     dependsOn(handleWeeklyRelease)
+    dependsOn(handleMainRelease)
 }
 
 data class GitHubUser(val name: String, val email: String, val authToken: String?)

--- a/buildSrc/src/main/java/org/zaproxy/gradle/HandleMainRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/HandleMainRelease.java
@@ -1,0 +1,48 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.zaproxy.gradle.ReleaseState.VersionChange;
+
+/**
+ * Task that handles a main release, if any.
+ *
+ * <p>Sends a repository dispatch to release the main Docker images.
+ */
+public abstract class HandleMainRelease extends SendRepositoryDispatch {
+
+    @InputFile
+    public abstract RegularFileProperty getReleaseState();
+
+    @Override
+    void send() {
+        ReleaseState releaseState = ReleaseState.read(getReleaseState().getAsFile().get());
+        if (isNewMainRelease(releaseState)) {
+            super.send();
+        }
+    }
+
+    private static boolean isNewMainRelease(ReleaseState releaseState) {
+        VersionChange mainRelease = releaseState.getMainRelease();
+        return mainRelease != null && mainRelease.isNewVersion();
+    }
+}


### PR DESCRIPTION
Send repository dispatch to zaproxy to build the main Docker images
(stable and bare) when the main version is released.