### PR TITLE
Use Maven Central only

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ tasks.withType<JavaCompile> {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 buildDir = file("buildGradle")
@@ -48,7 +48,9 @@ dependencies {
     "errorprone"("com.google.errorprone:error_prone_core:2.3.1")
 
     compile("org.kohsuke:github-api:1.101")
-    compileOnly("com.infradna.tool:bridge-method-annotation:1.18")
+    compileOnly("com.infradna.tool:bridge-method-annotation:1.18") {
+        exclude(group = "org.jenkins-ci")
+    }
     compileOnly("com.github.spotbugs:spotbugs-annotations:3.1.12")
     compile("net.sf.json-lib:json-lib:2.4:jdk15")
     compile("org.zaproxy:zap:2.7.0")


### PR DESCRIPTION
Remove usage of JCenter, which will be retired.