### PR TITLE
Order website tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,6 +200,10 @@ val copyWebsiteGeneratedData by tasks.registering(Copy::class) {
     }
 }
 
+updateZapVersionWebsiteData {
+    mustRunAfter(copyWebsiteGeneratedData)
+}
+
 val updateWebsite by tasks.registering(UpdateWebsite::class) {
     dependsOn(copyWebsiteGeneratedData)
     dependsOn(updateZapVersionWebsiteData)


### PR DESCRIPTION
Ensure copy of generated website data is done before replacing the
ZAP version (no file currently overlaps).