### PR TITLE
News: Report competition extended

### DIFF
--- a/files/news/2_10.xml
+++ b/files/news/2_10.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
     <news>
-        <id>16</id>
+        <id>17</id>
         <default>
-            <item>Sign up for an AMA with Simon Bennetts on June 30th - 8am PT / 4pm BST</item>
-            <link>https://stackhawk.typeform.com/to/gWvpePYD</link>
+            <item>The ZAP Reporting Competition has been extended until October 1st!</item>
+            <link>https://www.zaproxy.org/blog/2021-03-12-report-competition/</link>
         </default>
     </news>
 </ZAP>

--- a/files/news/dev.xml
+++ b/files/news/dev.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ZAP>
     <news>
-        <id>16</id>
+        <id>17</id>
         <default>
-            <item>Sign up for an AMA with Simon Bennetts on June 30th - 8am PT / 4pm BST</item>
-            <link>https://stackhawk.typeform.com/to/gWvpePYD</link>
+            <item>The ZAP Reporting Competition has been extended until October 1st!</item>
+            <link>https://www.zaproxy.org/blog/2021-03-12-report-competition/</link>
         </default>
     </news>
 </ZAP>


### PR DESCRIPTION
It _is_ news but also its a good way to get rid of the AMA news item which is now too late - someones already told me they signed up by mistake this morning ;)
Should not be merged until https://github.com/zaproxy/zaproxy.github.io/pull/343 is also merged (just needs one more approval;)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>