### PR TITLE
Include OAST Support add-on for website help pages

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -55,6 +55,7 @@ jsonview
 jython
 kotlin
 neonmarker
+oast
 onlineMenu
 openapi
 plugnhack


### PR DESCRIPTION
Add the add-on ID to the list of included add-ons to generate the
website pages when the add-on is released.