### PR TITLE
Format localized resources in zap-extensions

### DIFF
--- a/src/main/crowdin-tasks.yml
+++ b/src/main/crowdin-tasks.yml
@@ -14,6 +14,7 @@
     - name: "crowdinCopyProjectTranslations"
       args: [ "--from=%packages_dir%" ]
     - name: "postProcessLocalizedHelpPages"
+    - name: "spotlessApply"
 
  - repo: "community-scripts"
    tasks:


### PR DESCRIPTION
Run `spotlessApply` after copying the localized resources, some add-ons
enforce the format.