### PR TITLE
Don't persist credentials in release workflows

### DIFF
--- a/.github/workflows/update-add-on-release.yml
+++ b/.github/workflows/update-add-on-release.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/update-daily-release.yml
+++ b/.github/workflows/update-daily-release.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/update-main-release.yml
+++ b/.github/workflows/update-main-release.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Do not persist the default credentials in release workflows as it's
causing a conflict with JGit (which should be using zapbot credentials).