### PR TITLE
Include Retest add-on for website help pages

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -70,6 +70,7 @@ regextester
 replacer
 reports
 requester
+retest
 retire
 reveal
 revisit


### PR DESCRIPTION
Add the add-on ID to the list of included add-ons to generate the
website pages when the add-on is released.