### PR TITLE
Use only closed issues for release notes

### DIFF
--- a/src/main/java/org/zaproxy/admin/GenerateReleaseNotes.java
+++ b/src/main/java/org/zaproxy/admin/GenerateReleaseNotes.java
@@ -52,7 +52,7 @@ public class GenerateReleaseNotes {
 
         GHRepository ghRepo = GitHub.connectAnonymously().getRepository(REPO);
         List<GHIssue> issues =
-                ghRepo.getIssues(GHIssueState.ALL, ghRepo.getMilestone(MILESTONE_NUMBER));
+                ghRepo.getIssues(GHIssueState.CLOSED, ghRepo.getMilestone(MILESTONE_NUMBER));
 
         Map<Integer, String> devIssuesMap = new HashMap<Integer, String>();
         Map<Integer, String> bugIssuesMap = new HashMap<Integer, String>();


### PR DESCRIPTION
Obtain only the closed issues when generating the release notes, for
when the release notes are generated before all issues are closed.