### PR TITLE
Update ZapVersions file for website weekly data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,7 +238,7 @@ val generateWebsiteMainReleaseData by tasks.registering(GenerateWebsiteMainRelea
 }
 
 val generateWebsiteWeeklyReleaseData by tasks.registering(GenerateWebsiteWeeklyReleaseData::class) {
-    zapVersions.set(latestZapVersions)
+    zapVersions.set(file(noAddOnsZapVersions))
     generatedDataComment.set(websiteGeneratedDataComment)
     into.set(file("$buildDir/e_weekly_files.yml"))
 }


### PR DESCRIPTION
Use the no add-ons ZapVersions file, the version specific ZapVersions
file is no longer being updated with weekly release info.