### PR TITLE
Update add-ons for website help pages

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -34,6 +34,7 @@ directorylistv2_3
 domxss
 encoder
 evalvillain
+exim
 exportreport
 formhandler
 fuzz
@@ -46,8 +47,6 @@ groovy
 highlighter
 hud
 imagelocationscanner
-importLogFiles
-importurls
 invoke
 jruby
 jsonview
@@ -77,8 +76,6 @@ retire
 reveal
 revisit
 saml
-saverawmessage
-savexmlmessage
 scripts
 selenium
 sequence


### PR DESCRIPTION
Add Import/Export add-on.
Remove related superseded add-ons:
 - Import files containing URLs;
 - Log File Importer;
 - Save Raw Message;
 - Save XML Message.

---
I am assuming that the superseded add-ons will not be released again and that the corresponding pages will be updated manually with the notice to use the newer add-on.