### PR TITLE
Correct commit message for daily releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,7 +201,7 @@ tasks {
         commitSummary.set("Update weekly release")
         commitDescription.set(
             provider {
-                val zapVersionsXml = CustomXmlConfiguration(latestZapVersions)
+                val zapVersionsXml = CustomXmlConfiguration(file(noAddOnsZapVersions))
                 val dailyVersion = zapVersionsXml.getString("core.daily-version")
                 "Update weekly release to version $dailyVersion."
             }


### PR DESCRIPTION
Use the ZapVersions.xml file to extract the version of the daily
release, the file in use was no longer being updated with daily
releases causing the version in the commit message to be wrong.