### PR TITLE
Remove date and lastmod fields from alert pages

### DIFF
--- a/.github/workflows/alert-docs.yml
+++ b/.github/workflows/alert-docs.yml
@@ -1,6 +1,8 @@
 name: Generate alert docs for website
 on: 
   workflow_dispatch:
+  schedule: # The start of every Friday
+    - cron: '0 0 * * 5'
 
 jobs:
   update-alerts:
@@ -31,9 +33,11 @@ jobs:
         git checkout -b update-alerts
         # Update the index to be sure git is aware of changes
         git update-index -q --refresh
-        # Generate a PR
-        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zaproxy-website.git
-        git add site
-        git commit -m "Update alert pages" --signoff
-        git push --set-upstream origin update-alerts --force
-        hub pull-request -b zaproxy:master --no-edit
+        ## If there are changes: comment, commit, PR
+        if ! git diff-index --quiet HEAD --; then
+          git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zaproxy-website.git
+          git add site
+          git commit -m "Update alert pages" --signoff
+          git push --set-upstream origin update-alerts --force
+          hub pull-request -b zaproxy:master --no-edit
+        fi

--- a/scripts/generate_alert_pages.js
+++ b/scripts/generate_alert_pages.js
@@ -132,8 +132,6 @@ function printAlerts(alerts, name, type, status, clazz, scripturl) {
 		}
 		pw.println('code: ' + codeurl);
 		pw.println('linktext: "' + linktext + '"');
-		pw.println('date: ' + date);
-		pw.println('lastmod: ' + date);
 		pw.println('---');
 		pw.close();
 	}


### PR DESCRIPTION
This will mean that we can run this script on a schedule and only get PRs if the details actually change.
Apart from the first run when all of the dates will go ;)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>