### PR TITLE
Remove colons from add-on dir name

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/gradle/website/Utils.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/website/Utils.java
@@ -52,7 +52,7 @@ final class Utils {
         return addOnTocItem
                 .getText()
                 .toLowerCase(Locale.ROOT)
-                .replaceAll("[ /]", "-")
+                .replaceAll("[ /:]", "-")
                 .replaceAll("-{2,}", "-");
     }
 


### PR DESCRIPTION
Do not include the colon as it's not necessary for the add-on directory
when generating its help pages.