### PR TITLE
Add database to add-on help publishing list

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -27,6 +27,7 @@ commonlib
 communityScripts
 custompayloads
 customreport
+database
 diff
 directorylistv1
 directorylistv2_3_lc


### PR DESCRIPTION
Noticed that the link to the database add-on help was broken in the ZAP 2.12.0 release blog post.
https://www.zaproxy.org/docs/desktop/addons/database/