### PR TITLE
Include Dev add-on for website help pages

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -29,6 +29,7 @@ communityScripts
 custompayloads
 customreport
 database
+dev
 diff
 directorylistv1
 directorylistv2_3_lc


### PR DESCRIPTION
Add the add-on ID to the list of included add-ons to generate the website pages when the add-on is released.