### PR TITLE
Remove amf add-on from dev and website

### DIFF
--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -107,31 +107,6 @@
         <size>249532</size>
         <not-before-version>2.11.0</not-before-version>
     </addon_allinonenotes>
-    <addon>amf</addon>
-    <addon_amf>
-        <name>AMF Support</name>
-        <description>Adds support for AMF messages</description>
-        <author>ZAP Dev Team</author>
-        <version>3</version>
-        <file>amf-alpha-3.zap</file>
-        <status>alpha</status>
-        <changes>&lt;h3&gt;Added&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Add help.&lt;/li&gt;
-&lt;li&gt;Add info and repo URLs.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h3&gt;Changed&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Update minimum ZAP version to 2.11.0.&lt;/li&gt;
-&lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/amf-v3/amf-alpha-3.zap</url>
-        <hash>SHA-256:01345ea00a6623d794753a3210f4e3e2b50a8c4ce2bfa6ea57324f0ff01ad7e3</hash>
-        <info>https://www.zaproxy.org/docs/desktop/addons/amf-support/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
-        <date>2021-10-07</date>
-        <size>911943</size>
-        <not-before-version>2.11.0</not-before-version>
-    </addon_amf>
     <addon>ascanrules</addon>
     <addon_ascanrules>
         <name>Active scanner rules</name>

--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -8,7 +8,6 @@ accessControl
 alertFilters
 alertReport
 allinonenotes
-amf
 ascanrulesAlpha
 ascanrulesBeta
 ascanrules


### PR DESCRIPTION
No longer make it available when running the weekly or source.
Remove from the website help generation.