### PR TITLE
Allow to trigger the Handle Release workflow

### DIFF
--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -1,6 +1,7 @@
 name: Handle Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - master


### PR DESCRIPTION
For cases where the website data needs to be regenerated without a release being done.