### PR TITLE
Replace `hub` with `gh` in workflows

### DIFF
--- a/.github/workflows/alert-docs.yml
+++ b/.github/workflows/alert-docs.yml
@@ -39,5 +39,5 @@ jobs:
           git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zaproxy-website.git
           git commit -m "Update alert pages" --signoff
           git push --set-upstream origin update-alerts --force
-          hub pull-request -b zaproxy:main --no-edit
+          gh pr create -R zaproxy/zaproxy-website -f
         fi

--- a/.github/workflows/event-docs.yml
+++ b/.github/workflows/event-docs.yml
@@ -36,4 +36,4 @@ jobs:
         git add site/data/events.yaml
         git commit -m "Update events page" --signoff
         git push --set-upstream origin update-events --force
-        hub pull-request -b zaproxy:main --no-edit
+        gh pr create -R zaproxy/zaproxy-website -f


### PR DESCRIPTION
Signed-off-by: ricekot <github@ricekot.com>
