### PR TITLE
Include SBOM components' version when sorting

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/gradle/website/PageFrontMatter.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/website/PageFrontMatter.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.RepresentToNode;
@@ -114,9 +115,9 @@ class PageFrontMatter {
     static class SbomData {
         private final String bomFormat;
         private final String downloadUrl;
-        private final List<SbomDataComponent> components;
+        private final Set<SbomDataComponent> components;
 
-        SbomData(String bomFormat, String downloadUrl, List<SbomDataComponent> components) {
+        SbomData(String bomFormat, String downloadUrl, Set<SbomDataComponent> components) {
             this.bomFormat = bomFormat;
             this.downloadUrl = downloadUrl;
             this.components = components;
@@ -130,12 +131,12 @@ class PageFrontMatter {
             return downloadUrl;
         }
 
-        public List<SbomDataComponent> getComponents() {
+        public Set<SbomDataComponent> getComponents() {
             return components;
         }
     }
 
-    static class SbomDataComponent {
+    static class SbomDataComponent implements Comparable<SbomDataComponent> {
         private final String name;
         private final String version;
         private final String licenses;
@@ -157,6 +158,19 @@ class PageFrontMatter {
 
         public String getLicenses() {
             return licenses;
+        }
+
+        @Override
+        public int compareTo(SbomDataComponent o) {
+            int result = name.compareTo(o.name);
+            if (result != 0) {
+                return result;
+            }
+            result = version.compareTo(o.version);
+            if (result != 0) {
+                return result;
+            }
+            return licenses.compareTo(o.licenses);
         }
     }
 

--- a/buildSrc/src/main/java/org/zaproxy/gradle/website/WebsiteSbomPageGenerator.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/website/WebsiteSbomPageGenerator.java
@@ -26,9 +26,8 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -48,13 +47,9 @@ public class WebsiteSbomPageGenerator {
             throws Exception {
         PageFrontMatter frontMatter = new PageFrontMatter("sbom", pageTitle, 1);
         JsonNode bomJson = MAPPER.readTree(bomPath.toFile());
-        List<PageFrontMatter.SbomDataComponent> resultComponents = new ArrayList<>();
+        Set<PageFrontMatter.SbomDataComponent> resultComponents = new TreeSet<>();
         var componentsJsonArray = (ArrayNode) bomJson.get("components");
-        List<JsonNode> sortedComponentsList =
-                StreamSupport.stream(componentsJsonArray.spliterator(), false)
-                        .sorted(Comparator.comparing(jsonNode -> jsonNode.get("name").asText()))
-                        .collect(Collectors.toList());
-        for (JsonNode component : sortedComponentsList) {
+        for (JsonNode component : componentsJsonArray) {
             resultComponents.add(
                     new PageFrontMatter.SbomDataComponent(
                             component.get("name").asText(),


### PR DESCRIPTION
Ensure the components have a predictable order always.
Also, use a set to avoid listing duplicates.