### PR TITLE
Remove repo from codedx

### DIFF
--- a/ZapVersions-2.14.xml
+++ b/ZapVersions-2.14.xml
@@ -574,7 +574,6 @@
         <url>https://github.com/zaproxy/zap-extensions/releases/download/codedx-v9/codedx-alpha-9.zap</url>
         <hash>SHA-256:767e0a098de281f0bc880b036a5192f26fe0bb014b81227b385a0b63ca570428</hash>
         <info>https://www.zaproxy.org/docs/desktop/addons/code-dx/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
         <date>2021-10-07</date>
         <size>1769797</size>
         <not-before-version>2.11.0</not-before-version>


### PR DESCRIPTION
The add-on is no longer in `zap-extensions`.