### PR TITLE
Remove Java 11 requirement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,12 +66,6 @@ val copyZapVersions = tasks.create<Copy>("copyZapVersions") {
     include("ZapVersions*.xml")
 }
 
-java {
-    val javaVersion = JavaVersion.VERSION_11
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,14 +8,10 @@ repositories {
     mavenCentral()
 }
 
-val javaVersion = JavaVersion.VERSION_11
-java {
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-kotlin {
-    jvmToolchain(11)
+tasks.withType<JavaCompile>().configureEach {
+    if (JavaVersion.current().getMajorVersion() >= "21") {
+       options.compilerArgs = options.compilerArgs + "-Xlint:-this-escape"
+    }
 }
 
 dependencies {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteSbomPages.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/GenerateWebsiteSbomPages.java
@@ -73,7 +73,7 @@ public abstract class GenerateWebsiteSbomPages extends DefaultTask {
             Path bomPath = getTemporaryDir().toPath().resolve(addOnId + ".cdx.json");
             try {
                 TaskUtils.downloadFile(this, bomUrl, bomPath);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 getLogger().warn(e.getMessage(), e);
                 continue;
             }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/SendRepositoryDispatch.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/SendRepositoryDispatch.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -89,8 +89,8 @@ public abstract class SendRepositoryDispatch extends DefaultTask {
                 String.format("https://api.github.com/repos/%s/dispatches", getGitHubRepo().get());
         HttpURLConnection connection;
         try {
-            connection = (HttpURLConnection) new URL(url).openConnection();
-        } catch (IOException e) {
+            connection = (HttpURLConnection) new URI(url).toURL().openConnection();
+        } catch (Exception e) {
             throw new TaskException("Failed to create the connection:", e);
         }
         connection.setDoOutput(true);

--- a/buildSrc/src/main/java/org/zaproxy/gradle/TaskUtils.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/TaskUtils.java
@@ -21,6 +21,7 @@ package org.zaproxy.gradle;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -40,16 +41,16 @@ final class TaskUtils {
     private static final String HTTPS_SCHEME = "HTTPS";
     private static final String ADD_ON_EXTENSION = ".zap";
 
-    static Path downloadAddOn(Task task, String urlString) throws IOException {
+    static Path downloadAddOn(Task task, String urlString) throws Exception {
         return downloadAddOn(task, urlString, task.getTemporaryDir().toPath());
     }
 
-    static Path downloadAddOn(Task task, String urlString, Path outputDir) throws IOException {
+    static Path downloadAddOn(Task task, String urlString, Path outputDir) throws Exception {
         return downloadFile(task, urlString, outputDir.resolve(extractFileName(urlString)));
     }
 
-    static Path downloadFile(Task task, String urlString, Path outputFile) throws IOException {
-        URL url = new URL(urlString);
+    static Path downloadFile(Task task, String urlString, Path outputFile) throws Exception {
+        URL url = new URI(urlString).toURL();
         if (!HTTPS_SCHEME.equalsIgnoreCase(url.getProtocol())) {
             throw new IllegalArgumentException(
                     "The provided URL does not use HTTPS scheme: " + url.getProtocol());

--- a/buildSrc/src/main/java/org/zaproxy/gradle/UpdateAddOnZapVersionsEntries.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/UpdateAddOnZapVersionsEntries.java
@@ -20,6 +20,7 @@
 package org.zaproxy.gradle;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -115,13 +116,13 @@ public abstract class UpdateAddOnZapVersionsEntries extends AbstractUpdateZapVer
         }
 
         try {
-            URL url = new URL(downloadUrl.get());
+            URL url = new URI(downloadUrl.get()).toURL();
             if (!TaskUtils.hasSecureScheme(url)) {
                 throw new IllegalArgumentException(
                         "The provided download URL does not use HTTPS scheme: "
                                 + url.getProtocol());
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Failed to parse the download URL: " + e.getMessage(), e);
         }
@@ -129,7 +130,7 @@ public abstract class UpdateAddOnZapVersionsEntries extends AbstractUpdateZapVer
         updateAddOn(getAddOn(), getDownloadUrl().get(), getReleaseDate().get());
     }
 
-    private Path getAddOn() throws IOException {
+    private Path getAddOn() throws Exception {
         if (getFromFile().isPresent()) {
             Path addOn = getFromFile().getAsFile().get().toPath();
             if (!Files.isRegularFile(addOn)) {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/UpdateDailyZapVersionsEntries.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/UpdateDailyZapVersionsEntries.java
@@ -21,6 +21,7 @@ package org.zaproxy.gradle;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -126,7 +127,7 @@ public abstract class UpdateDailyZapVersionsEntries extends AbstractUpdateZapVer
         return fileName.substring(beginIdx, endIdx);
     }
 
-    private Path getReleaseFile() throws IOException {
+    private Path getReleaseFile() throws Exception {
         if (getFrom().isPresent()) {
             Path release = getFrom().getAsFile().get().toPath();
             if (!Files.isRegularFile(release)) {
@@ -142,7 +143,7 @@ public abstract class UpdateDailyZapVersionsEntries extends AbstractUpdateZapVer
         }
 
         String urlString = getFromUrl().get();
-        URL url = new URL(urlString);
+        URL url = new URI(urlString).toURL();
         if (!HTTPS_SCHEME.equalsIgnoreCase(url.getProtocol())) {
             throw new IllegalArgumentException(
                     "The provided URL does not use HTTPS scheme: " + url.getProtocol());

--- a/buildSrc/src/main/java/org/zaproxy/gradle/UpdateMainZapVersionsEntries.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/UpdateMainZapVersionsEntries.java
@@ -21,6 +21,7 @@ package org.zaproxy.gradle;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -105,13 +106,13 @@ public abstract class UpdateMainZapVersionsEntries extends AbstractUpdateZapVers
 
         String finalBaseDownloadUrl = replaceVersionTokens(getBaseDownloadUrl().get());
         try {
-            URL url = new URL(finalBaseDownloadUrl);
+            URL url = new URI(finalBaseDownloadUrl).toURL();
             if (!HTTPS_SCHEME.equalsIgnoreCase(url.getProtocol())) {
                 throw new IllegalArgumentException(
                         "The provided download URL does not use HTTPS scheme: "
                                 + url.getProtocol());
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Failed to parse the download URL: " + e.getMessage(), e);
         }
@@ -167,7 +168,7 @@ public abstract class UpdateMainZapVersionsEntries extends AbstractUpdateZapVers
                 .replace(VERSION_UNDERSCORES_TOKEN, versionUnderscores);
     }
 
-    private ReleaseFile createReleaseFile(String keyPrefix, String url) throws IOException {
+    private ReleaseFile createReleaseFile(String keyPrefix, String url) throws Exception {
         Path file = downloadFile(url);
         return new ReleaseFile(
                 keyPrefix,
@@ -181,8 +182,8 @@ public abstract class UpdateMainZapVersionsEntries extends AbstractUpdateZapVers
         return baseUrl + replaceVersionTokens(name);
     }
 
-    private Path downloadFile(String urlString) throws IOException {
-        URL url = new URL(urlString);
+    private Path downloadFile(String urlString) throws Exception {
+        URL url = new URI(urlString).toURL();
         if (!HTTPS_SCHEME.equalsIgnoreCase(url.getProtocol())) {
             throw new IllegalArgumentException(
                     "The provided URL does not use HTTPS scheme: " + url.getProtocol());

--- a/buildSrc/src/main/java/org/zaproxy/gradle/website/Utils.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/website/Utils.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.gradle.website;
 
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -86,8 +86,9 @@ final class Utils {
 
     static URL createUrlFor(URL file, String path) {
         try {
-            return new URL(file, path);
-        } catch (MalformedURLException e) {
+            var resolved = new URI(file.getPath()).resolve(path);
+            return new URI(file.getProtocol(), resolved.toASCIIString(), null).toURL();
+        } catch (Exception e) {
             throw new WebsitePageGenerationException(
                     "Failed to create the URL with " + file + " and " + path, e);
         }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/website/WebsitePageGenerator.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/website/WebsitePageGenerator.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -323,8 +325,8 @@ public class WebsitePageGenerator {
                             String newSourceUrl = contentsDir + "/" + href;
 
                             try {
-                                to = addSourcePage(new URL(newSourceUrl));
-                            } catch (MalformedURLException e) {
+                                to = addSourcePage(new URI(newSourceUrl).toURL());
+                            } catch (URISyntaxException | MalformedURLException e) {
                                 throw new WebsitePageGenerationException(
                                         "Failed to create URL from: " + newSourceUrl);
                             }


### PR DESCRIPTION
Build always with the Java version provided, as all the targeted versions are now supported.
Disable the lint `this-escape` to pass the compilation.
Address other warns.