### PR TITLE
Remove portscan

### DIFF
--- a/ZapVersions-2.15.xml
+++ b/ZapVersions-2.15.xml
@@ -2085,36 +2085,6 @@
             </addons>
         </dependencies>
     </addon_plugnhack>
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>portscan-beta-10.zap</file>
-        <status>beta</status>
-        <changes>&lt;h3&gt;Changed&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Use the Network add-on to obtain the outgoing proxy.&lt;/li&gt;
-&lt;li&gt;Maintenance changes.&lt;/li&gt;
-&lt;li&gt;Update minimum ZAP version to 2.12.0.&lt;/li&gt;
-&lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/portscan-v10/portscan-beta-10.zap</url>
-        <hash>SHA-256:6cf0432e1c329499649b219d2f00e7ec7bc2079d7160396fecb9a8ad3446b963</hash>
-        <info>https://www.zaproxy.org/docs/desktop/addons/port-scan/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
-        <date>2022-10-27</date>
-        <size>724563</size>
-        <not-before-version>2.12.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>network</id>
-                    <version>&gt;=0.3.0</version>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_portscan>
     <addon>postman</addon>
     <addon_postman>
         <name>Postman Support</name>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -2086,36 +2086,6 @@
             </addons>
         </dependencies>
     </addon_plugnhack>
-    <addon>portscan</addon>
-    <addon_portscan>
-        <name>Port Scanner</name>
-        <description>Allows to port scan a target server</description>
-        <author>ZAP Dev Team</author>
-        <version>10</version>
-        <file>portscan-beta-10.zap</file>
-        <status>beta</status>
-        <changes>&lt;h3&gt;Changed&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Use the Network add-on to obtain the outgoing proxy.&lt;/li&gt;
-&lt;li&gt;Maintenance changes.&lt;/li&gt;
-&lt;li&gt;Update minimum ZAP version to 2.12.0.&lt;/li&gt;
-&lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/portscan-v10/portscan-beta-10.zap</url>
-        <hash>SHA-256:6cf0432e1c329499649b219d2f00e7ec7bc2079d7160396fecb9a8ad3446b963</hash>
-        <info>https://www.zaproxy.org/docs/desktop/addons/port-scan/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
-        <date>2022-10-27</date>
-        <size>724563</size>
-        <not-before-version>2.12.0</not-before-version>
-        <dependencies>
-            <addons>
-                <addon>
-                    <id>network</id>
-                    <version>&gt;=0.3.0</version>
-                </addon>
-            </addons>
-        </dependencies>
-    </addon_portscan>
     <addon>postman</addon>
     <addon_postman>
         <name>Postman Support</name>

--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -68,7 +68,6 @@ packscanrules
 packscripts
 paramdigger
 plugnhack
-portscan
 postman
 pscanrulesAlpha
 pscanrulesBeta


### PR DESCRIPTION
As per plan of discontinuing the portscan add-on, as better/specific tools exist.