### PR TITLE
Update generate_alert_pages.js script

### DIFF
--- a/scripts/generate_alert_pages.js
+++ b/scripts/generate_alert_pages.js
@@ -352,7 +352,11 @@ function getPrivateMethod(obj, methods, key, defaultVal) {
 function printPscanRule(plugin) {
 	plugin.setHelper(passiveScanData);
 
-	var examples = getPrivateMethod(plugin, ['getExampleAlerts'], '', null);
+	try {
+		var examples = plugin.getExampleAlerts()
+	} catch (e) {
+		var examples = getPrivateMethod(plugin, ['getExampleAlerts'], '', null);
+	}
 
 	if (examples == null || examples.length == 0) {
 		var alert = new Alert(plugin.getPluginId());


### PR DESCRIPTION
`getExampleAlerts` is a public method for most scan rules and reflection is not needed to access it.

The reason this change was needed is that reflection was failing for `PassiveScriptScanRule`s. This is probably because we are using `ByteBuddy` to dynamically create a unique class for each passive script but I haven't checked in detail.

Without this change, many details are missing from the generated alert pages for passive scripts (e.g. see https://github.com/zaproxy/zaproxy-website/pull/2702).