### PR TITLE
Include scanpolicies add-on for website help pages

### DIFF
--- a/src/main/addons-help-website.txt
+++ b/src/main/addons-help-website.txt
@@ -83,6 +83,7 @@ retire
 reveal
 revisit
 saml
+scanpolicies
 scripts
 selenium
 sequence


### PR DESCRIPTION
Add the add-on ID to the list of included add-ons to generate the website pages when the add-on is released.