### PR TITLE
Remove treetools

### DIFF
--- a/ZapVersions-2.17.xml
+++ b/ZapVersions-2.17.xml
@@ -3207,32 +3207,6 @@ but if you encounter problems, please refer to the following.
         <size>543902</size>
         <not-before-version>2.17.0</not-before-version>
     </addon_tokengen>
-    <addon>treetools</addon>
-    <addon_treetools>
-        <name>TreeTools</name>
-        <description>Tools to add functionality to the tree view.</description>
-        <author>Carl Sampson</author>
-        <version>8</version>
-        <file>treetools-beta-8.zap</file>
-        <status>beta</status>
-        <changes>&lt;h3&gt;Added&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Add help.&lt;/li&gt;
-&lt;li&gt;Add info and repo URLs.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h3&gt;Changed&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Update minimum ZAP version to 2.11.0.&lt;/li&gt;
-&lt;li&gt;Maintenance changes.&lt;/li&gt;
-&lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/treetools-v8/treetools-beta-8.zap</url>
-        <hash>SHA-256:b7f61f8939937ebc120bce8deb72713d7676087056e88801df2573112e7642e4</hash>
-        <info>https://www.zaproxy.org/docs/desktop/addons/treetools/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
-        <date>2021-10-07</date>
-        <size>128931</size>
-        <not-before-version>2.11.0</not-before-version>
-    </addon_treetools>
     <addon>viewstate</addon>
     <addon_viewstate>
         <name>ViewState</name>

--- a/ZapVersions-dev.xml
+++ b/ZapVersions-dev.xml
@@ -3207,32 +3207,6 @@ but if you encounter problems, please refer to the following.
         <size>543902</size>
         <not-before-version>2.17.0</not-before-version>
     </addon_tokengen>
-    <addon>treetools</addon>
-    <addon_treetools>
-        <name>TreeTools</name>
-        <description>Tools to add functionality to the tree view.</description>
-        <author>Carl Sampson</author>
-        <version>8</version>
-        <file>treetools-beta-8.zap</file>
-        <status>beta</status>
-        <changes>&lt;h3&gt;Added&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Add help.&lt;/li&gt;
-&lt;li&gt;Add info and repo URLs.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h3&gt;Changed&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;Update minimum ZAP version to 2.11.0.&lt;/li&gt;
-&lt;li&gt;Maintenance changes.&lt;/li&gt;
-&lt;/ul&gt;</changes>
-        <url>https://github.com/zaproxy/zap-extensions/releases/download/treetools-v8/treetools-beta-8.zap</url>
-        <hash>SHA-256:b7f61f8939937ebc120bce8deb72713d7676087056e88801df2573112e7642e4</hash>
-        <info>https://www.zaproxy.org/docs/desktop/addons/treetools/</info>
-        <repo>https://github.com/zaproxy/zap-extensions/</repo>
-        <date>2021-10-07</date>
-        <size>128931</size>
-        <not-before-version>2.11.0</not-before-version>
-    </addon_treetools>
     <addon>viewstate</addon>
     <addon_viewstate>
         <name>ViewState</name>


### PR DESCRIPTION
The functionality that the add-on provided is now in the Common Library add-on.

---
Ref: https://github.com/zaproxy/zap-extensions/pull/7396